### PR TITLE
disabled vml cast exception

### DIFF
--- a/src/Prism.Maui/Mvvm/ViewModelLocator.cs
+++ b/src/Prism.Maui/Mvvm/ViewModelLocator.cs
@@ -9,7 +9,7 @@ public static class ViewModelLocator
     /// Instructs Prism whether or not to automatically create an instance of a ViewModel using a convention, and assign the associated View's <see cref="BindableObject.BindingContext"/> to that instance.
     /// </summary>
     public static readonly BindableProperty AutowireViewModelProperty =
-        BindableProperty.CreateAttached("AutowireViewModel", typeof(ViewModelLocatorBehavior), typeof(ViewModelLocator), ViewModelLocatorBehavior.Automatic, propertyChanged: OnAutowireViewModelChanged);
+        BindableProperty.CreateAttached("AutowireViewModel", typeof(ViewModelLocatorBehavior), typeof(ViewModelLocator), ViewModelLocatorBehavior.Automatic);
 
     internal static readonly BindableProperty ViewModelProperty =
         BindableProperty.CreateAttached("ViewModelType",
@@ -39,15 +39,6 @@ public static class ViewModelLocator
     public static void SetAutowireViewModel(BindableObject bindable, ViewModelLocatorBehavior value)
     {
         bindable.SetValue(AutowireViewModelProperty, value);
-    }
-
-    private static void OnAutowireViewModelChanged(BindableObject bindable, object oldValue, object newValue)
-    {
-        bool? bNewValue = (bool?)newValue;
-        if (bNewValue.HasValue && bNewValue.Value)
-        {
-            ViewModelLocationProvider2.AutoWireViewModelChanged(bindable, Bind);
-        }
     }
 
     private static void OnViewModelPropertyChanged(BindableObject bindable, object oldValue, object newValue)

--- a/tests/Prism.Maui.Tests/Fixtures/Navigation/ViewRegistryFixture.cs
+++ b/tests/Prism.Maui.Tests/Fixtures/Navigation/ViewRegistryFixture.cs
@@ -105,4 +105,21 @@ public class ViewRegistryFixture
         Assert.Single(page.Behaviors);
         Assert.IsType<PageLifeCycleAwareBehavior>(page.Behaviors.First());
     }
+
+    [Fact]
+    public void CreateView_WithViewModelLocator_Disabled()
+    {
+        var container = new TestContainer();
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<VMLDisabledPageMock>();
+
+        var registry = container.Resolve<NavigationRegistry>();
+        VMLDisabledPageMock page = null;
+
+        var ex = Record.Exception(() => page = registry.CreateView(container, "VMLDisabledPageMock") as VMLDisabledPageMock);
+
+        Assert.Null(ex);
+        Assert.NotNull(page);
+        Assert.IsNotType<VMLDisabledPageMockViewModel>(page.BindingContext);
+    }
 }

--- a/tests/Prism.Maui.Tests/Mocks/ViewModels/VMLDisabledPageMockViewModel.cs
+++ b/tests/Prism.Maui.Tests/Mocks/ViewModels/VMLDisabledPageMockViewModel.cs
@@ -1,0 +1,6 @@
+﻿namespace Prism.Maui.Tests.Mocks.ViewModels;
+
+// This should not be autowired
+public class VMLDisabledPageMockViewModel
+{
+}

--- a/tests/Prism.Maui.Tests/Mocks/Views/VMLDisabledPageMock.cs
+++ b/tests/Prism.Maui.Tests/Mocks/Views/VMLDisabledPageMock.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.Maui.Controls;
+
+namespace Prism.Maui.Tests.Mocks.Views;
+
+public class VMLDisabledPageMock : ContentPage
+{
+    public VMLDisabledPageMock()
+    {
+        SetValue(ViewModelLocator.AutowireViewModelProperty, ViewModelLocatorBehavior.Disabled);
+    }
+}


### PR DESCRIPTION
# Description

Removes property changed callback that incorrectly casted the value to a bool?. This is no longer necessary as we will autowire at a later time.

- fixes #58