### PR TITLE
Region Default View

### DIFF
--- a/sample/MauiRegionsModule/MauiTestRegionsModule.cs
+++ b/sample/MauiRegionsModule/MauiTestRegionsModule.cs
@@ -16,6 +16,9 @@ public class MauiTestRegionsModule : IModule
         containerRegistry
             .RegisterForNavigation<ContentRegionPage>()
             .RegisterForNavigation<RegionHome, RegionHomeViewModel>()
+            .RegisterForNavigation<DefaultViewNamedPage>()
+            .RegisterForNavigation<DefaultViewInstancePage>()
+            .RegisterForNavigation<DefaultViewTypePage>()
             .RegisterForRegionNavigation<RegionViewA, RegionViewAViewModel>()
             .RegisterForRegionNavigation<RegionViewB, RegionViewBViewModel>()
             .RegisterForRegionNavigation<RegionViewC, RegionViewCViewModel>();

--- a/sample/MauiRegionsModule/ViewModels/RegionViewAViewModel.cs
+++ b/sample/MauiRegionsModule/ViewModels/RegionViewAViewModel.cs
@@ -2,11 +2,17 @@
 
 namespace MauiRegionsModule.ViewModels;
 
-public class RegionViewAViewModel : RegionViewModelBase
+public class RegionViewAViewModel : RegionViewModelBase, IInitialize
 {
     public RegionViewAViewModel(INavigationService navigationService, IPageAccessor pageAccessor) 
         : base(navigationService, pageAccessor)
     {
+    }
+
+    public void Initialize(INavigationParameters parameters)
+    {
+        if (parameters.TryGetValue<string>("Message", out var message))
+            Message = message;
     }
 }
 

--- a/sample/MauiRegionsModule/Views/DefaultViewInstancePage.xaml
+++ b/sample/MauiRegionsModule/Views/DefaultViewInstancePage.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             xmlns:local="clr-namespace:MauiRegionsModule.Views"
+             x:Class="MauiRegionsModule.Views.DefaultViewInstancePage"
+             Title="DefaultViewInstancePage">
+  <ContentPage.Resources>
+    <ResourceDictionary>
+      <ContentView x:Key="InstanceView">
+        <StackLayout>
+          <Label Text="This is an instance of a View" />
+          <Label Text="This has no View Model and is simply an instance we add by default." />
+        </StackLayout>
+      </ContentView>
+    </ResourceDictionary>
+  </ContentPage.Resources>
+
+  <ContentView prism:RegionManager.RegionName="DefaultViewNamed"
+               prism:RegionManager.DefaultView="{StaticResource InstanceView}" />
+</ContentPage>

--- a/sample/MauiRegionsModule/Views/DefaultViewInstancePage.xaml.cs
+++ b/sample/MauiRegionsModule/Views/DefaultViewInstancePage.xaml.cs
@@ -1,0 +1,9 @@
+namespace MauiRegionsModule.Views;
+
+public partial class DefaultViewInstancePage : ContentPage
+{
+    public DefaultViewInstancePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/sample/MauiRegionsModule/Views/DefaultViewNamedPage.xaml
+++ b/sample/MauiRegionsModule/Views/DefaultViewNamedPage.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             x:Class="MauiRegionsModule.Views.DefaultViewNamedPage"
+             Title="Default View Named">
+  <ContentView prism:RegionManager.RegionName="DefaultViewNamed"
+               prism:RegionManager.DefaultView="RegionViewA" />
+</ContentPage>

--- a/sample/MauiRegionsModule/Views/DefaultViewNamedPage.xaml.cs
+++ b/sample/MauiRegionsModule/Views/DefaultViewNamedPage.xaml.cs
@@ -1,0 +1,9 @@
+namespace MauiRegionsModule.Views;
+
+public partial class DefaultViewNamedPage : ContentPage
+{
+    public DefaultViewNamedPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/sample/MauiRegionsModule/Views/DefaultViewTypePage.xaml
+++ b/sample/MauiRegionsModule/Views/DefaultViewTypePage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             xmlns:local="clr-namespace:MauiRegionsModule.Views"
+             x:Class="MauiRegionsModule.Views.DefaultViewTypePage"
+             Title="DefaultViewTypePage">
+  <ContentView prism:RegionManager.RegionName="DefaultViewNamed"
+               prism:RegionManager.DefaultView="{x:Type local:RegionViewA}"/>
+</ContentPage>

--- a/sample/MauiRegionsModule/Views/DefaultViewTypePage.xaml.cs
+++ b/sample/MauiRegionsModule/Views/DefaultViewTypePage.xaml.cs
@@ -1,0 +1,9 @@
+namespace MauiRegionsModule.Views;
+
+public partial class DefaultViewTypePage : ContentPage
+{
+    public DefaultViewTypePage()
+    {
+        InitializeComponent();
+    }
+}

--- a/sample/MauiRegionsModule/Views/RegionHome.xaml
+++ b/sample/MauiRegionsModule/Views/RegionHome.xaml
@@ -9,6 +9,15 @@
         <Button Text="Content Region"
                 Command="{Binding NavigateCommand}"
                 CommandParameter="NavigationPage/ContentRegionPage" />
+        <Button Text="Default View by Name"
+                Command="{Binding NavigateCommand}"
+                CommandParameter="NavigationPage/DefaultViewNamedPage?Message=Initialized%20by%20NavigationParameters" />
+        <Button Text="Default View by Type"
+                Command="{Binding NavigateCommand}"
+                CommandParameter="NavigationPage/DefaultViewTypePage" />
+        <Button Text="Default View by Instance"
+                Command="{Binding NavigateCommand}"
+                CommandParameter="NavigationPage/DefaultViewInstancePage" />
         <Button Text="Root Page"
                 Command="{Binding NavigateCommand}"
                 CommandParameter="/RootPage" />

--- a/src/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -47,6 +47,14 @@ public static class PrismAppBuilderExtensions
     public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, string uri) =>
         builder.OnAppStart(navigation => navigation.NavigateAsync(uri));
 
+    public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, string uri, Action<Exception> onError) =>
+        builder.OnAppStart(async navigation =>
+        {
+            var result = await navigation.NavigateAsync(uri);
+            if (result.Exception is not null)
+                onError(result.Exception);
+        });
+
     public static PrismAppBuilder OnAppStart(this PrismAppBuilder builder, Action<INavigationService> onAppStarted) =>
         builder.OnAppStart((_, n) => onAppStarted(n));
 

--- a/src/Prism.Maui/Regions/Xaml/RegionManager.cs
+++ b/src/Prism.Maui/Regions/Xaml/RegionManager.cs
@@ -57,6 +57,12 @@ public static class RegionManager
     public static readonly BindableProperty DefaultViewProperty =
         BindableProperty.CreateAttached("DefaultView", typeof(object), typeof(RegionManager), null);
 
+    public static void SetDefaultView(VisualElement regionTarget, object viewNameTypeOrInstance) => 
+        regionTarget.SetValue(DefaultViewProperty, viewNameTypeOrInstance);
+
+    public static object GetDefaultView(VisualElement regionTarget) =>
+        regionTarget.GetValue(DefaultViewProperty);
+
     /// <summary>
     /// Sets the <see cref="RegionNameProperty"/> attached property.
     /// </summary>

--- a/src/Prism.Maui/Regions/Xaml/RegionManager.cs
+++ b/src/Prism.Maui/Regions/Xaml/RegionManager.cs
@@ -54,6 +54,9 @@ public static class RegionManager
     public static readonly BindableProperty RegionContextProperty =
         BindableProperty.CreateAttached("RegionContext", typeof(object), typeof(RegionManager), null, propertyChanged: OnRegionContextChanged);
 
+    public static readonly BindableProperty DefaultViewProperty =
+        BindableProperty.CreateAttached("DefaultView", typeof(object), typeof(RegionManager), null);
+
     /// <summary>
     /// Sets the <see cref="RegionNameProperty"/> attached property.
     /// </summary>

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
@@ -172,4 +172,32 @@ public class RegionFixture
 
         Assert.Equal(2, children.Count());
     }
+
+    [Fact]
+    public void RegionWithDefaultView_IsAutoPopulated()
+    {
+        var mauiApp = MauiApp.CreateBuilder()
+            .UsePrismApp<Application>(prism =>
+                prism.RegisterTypes(container =>
+                {
+                    container.RegisterForNavigation<MockPageWithRegionAndDefaultView>("MainPage");
+                    container.RegisterForRegionNavigation<MockRegionViewA, MockRegionViewAViewModel>();
+                })
+                .OnAppStart("MainPage", ex => Assert.Null(ex)))
+            .Build();
+
+        var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
+
+        Assert.Single(app!.Windows);
+        var window = app.Windows.First();
+        Assert.NotNull(window.Page);
+
+        Assert.IsType<MockPageWithRegionAndDefaultView>(window.Page);
+        var page = window.Page as MockPageWithRegionAndDefaultView;
+
+        var region = page.Content as ContentView;
+
+        Assert.NotNull(region.Content);
+        Assert.IsType<MockRegionViewA>(region.Content);
+    }
 }

--- a/tests/Prism.DryIoc.Maui.Tests/Mocks/Views/MockPageWithRegionAndDefaultView.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Mocks/Views/MockPageWithRegionAndDefaultView.cs
@@ -1,0 +1,12 @@
+﻿namespace Prism.DryIoc.Maui.Tests.Mocks.Views;
+
+public class MockPageWithRegionAndDefaultView : ContentPage
+{
+    public MockPageWithRegionAndDefaultView()
+    {
+        var view = new ContentView();
+        view.SetValue(Prism.Regions.Xaml.RegionManager.RegionNameProperty, "Demo");
+        view.SetValue(Prism.Regions.Xaml.RegionManager.DefaultViewProperty, "MockRegionViewA");
+        Content = view;
+    }
+}


### PR DESCRIPTION
# Description

This adds a DefaultView Attached Property for the RegionManager. When specified on a given Region the Region AutoPopulate Behavior will evaluate the value from the TargetElement and add/create the specified View and add it to the Region. This will occur prior to Prism's Page Navigation interfaces firing meaning that you can tie into IInitialize, or INavigationAware to pass the context to the ViewModel of the Region View. Note that this will accept a name, type or View instance.

![image](https://user-images.githubusercontent.com/3860573/172252980-311d0601-2dfd-4058-b3f1-712d8804e800.png)


![image](https://user-images.githubusercontent.com/3860573/172252935-b155f11d-505b-4aac-bb0e-0678963ce712.png)

- closes #62 