### PR TITLE
Set Window.Page

### DIFF
--- a/sample/MauiRegionsModule/Views/DefaultViewInstancePage.xaml
+++ b/sample/MauiRegionsModule/Views/DefaultViewInstancePage.xaml
@@ -16,6 +16,6 @@
     </ResourceDictionary>
   </ContentPage.Resources>
 
-  <ContentView prism:RegionManager.RegionName="DefaultViewNamed"
+  <ContentView prism:RegionManager.RegionName="DefaultViewInstance"
                prism:RegionManager.DefaultView="{StaticResource InstanceView}" />
 </ContentPage>

--- a/sample/MauiRegionsModule/Views/DefaultViewTypePage.xaml
+++ b/sample/MauiRegionsModule/Views/DefaultViewTypePage.xaml
@@ -5,6 +5,6 @@
              xmlns:local="clr-namespace:MauiRegionsModule.Views"
              x:Class="MauiRegionsModule.Views.DefaultViewTypePage"
              Title="DefaultViewTypePage">
-  <ContentView prism:RegionManager.RegionName="DefaultViewNamed"
+  <ContentView prism:RegionManager.RegionName="DefaultViewType"
                prism:RegionManager.DefaultView="{x:Type local:RegionViewA}"/>
 </ContentPage>

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -902,8 +902,10 @@ public class PageNavigationService : INavigationService, IRegistryAware
             }
             else
             {
+#if !ANDROID
                 // BUG: https://github.com/dotnet/maui/issues/7275
-                //Window.Page = page;
+                Window.Page = page;
+#else
 
                 // HACK: This is the only way CURRENTLY to ensure that the UI resets for Absolute Navigation
                 var newWindow = new PrismWindow
@@ -913,6 +915,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
                 _application.OpenWindow(newWindow);
                 _application.CloseWindow(Window);
                 _window = null;
+#endif
             }
 
             return Task.FromResult<object>(null);

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -905,6 +905,9 @@ public class PageNavigationService : INavigationService, IRegistryAware
 #if !ANDROID
                 // BUG: https://github.com/dotnet/maui/issues/7275
                 Window.Page = page;
+#if WINDOWS
+                page.ForceLayout();
+#endif
 #else
 
                 // HACK: This is the only way CURRENTLY to ensure that the UI resets for Absolute Navigation

--- a/src/Prism.Maui/Prism.Maui.csproj
+++ b/src/Prism.Maui/Prism.Maui.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows')) and '$(MSBuildRuntimeType)' == 'Full'">$(TargetFrameworks);net6.0-windows10.0.17763</TargetFrameworks>
     <RootNamespace>Prism</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>

--- a/src/Prism.Maui/Prism.Maui.csproj
+++ b/src/Prism.Maui/Prism.Maui.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net6.0-android</TargetFrameworks>
     <RootNamespace>Prism</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>


### PR DESCRIPTION
# Description

On Android setting the Window.Page does not work. The work around to close the current window and open a new one (while not the greatest thing) does work on Android. It isn't the greatest on WinUI however where we end up with multiple windows and we're opening and closing windows on users.

This PR adds Multi-Targeting to Prism.Maui. We now only do the Open/Close trick on Android. On WinUI we additionally force Layout when setting a new Page on the Window as the layout has seemed to be messed up otherwise.