### PR TITLE
use weak reference

### DIFF
--- a/src/Prism.Maui/Common/PageAccessor.cs
+++ b/src/Prism.Maui/Common/PageAccessor.cs
@@ -2,5 +2,10 @@
 
 internal class PageAccessor : IPageAccessor
 {
-    public Page Page { get; set; }
+    private WeakReference<Page> _weakPage;
+    public Page Page
+    {
+        get => _weakPage?.TryGetTarget(out var target) ?? false ? target : null;
+        set => _weakPage = value is null ? null : new(value);
+    }
 }


### PR DESCRIPTION
# Description

Ensure that the PageAccessor maintains a WeakReference to the Page to help ensure that we do not cause a memory leak