### PR TITLE
#22 XAML Navigation Extensions

### DIFF
--- a/sample/MauiModule/Views/ViewA.xaml
+++ b/sample/MauiModule/Views/ViewA.xaml
@@ -34,7 +34,11 @@
     <Button Text="ViewB" 
             Command="{prism:NavigateTo 'ViewB'}"
             Margin="10"
-            Grid.Row="1" />
+            Grid.Row="1">
+      <Button.CommandParameter>
+        <prism:Parameter Key="Message" Value="Hi from View A!"/>
+      </Button.CommandParameter>
+    </Button>
     <Button Text="Show Alert Dialog" 
             Command="{Binding ShowPageDialog}"
             Margin="10"

--- a/sample/MauiModule/Views/ViewA.xaml
+++ b/sample/MauiModule/Views/ViewA.xaml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:prism="http://prismlibrary.com"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="MauiModule.Views.ViewA"
              Title="{Binding Title}"
@@ -31,8 +32,7 @@
     </CollectionView>
 
     <Button Text="ViewB" 
-            Command="{Binding NavigateCommand}" 
-            CommandParameter="ViewB"
+            Command="{prism:NavigateTo 'ViewB'}"
             Margin="10"
             Grid.Row="1" />
     <Button Text="Show Alert Dialog" 

--- a/sample/MauiModule/Views/ViewC.xaml
+++ b/sample/MauiModule/Views/ViewC.xaml
@@ -32,7 +32,7 @@
 
     <Button Text="ViewD"
             Command="{Binding NavigateCommand}"
-            CommandParameter="ViewB"
+            CommandParameter="ViewD"
             Margin="10"
             Grid.Row="1" />
     <Button Text="Show Alert Dialog"

--- a/sample/MauiModule/Views/ViewD.xaml
+++ b/sample/MauiModule/Views/ViewD.xaml
@@ -5,7 +5,7 @@
              x:Class="MauiModule.Views.ViewD"
              Title="{Binding Title}"
              BackgroundColor="White">
-  <Grid RowDefinitions="*,Auto"
+  <Grid RowDefinitions="*,Auto,Auto"
         ColumnDefinitions="*,*">
     <CollectionView ItemsSource="{Binding Messages}"
                     Grid.ColumnSpan="2">
@@ -35,10 +35,14 @@
             Command="{prism:GoBack}"
             Margin="10"
             Grid.Row="1" />
+    <Button Text="Go Back To Root"
+            Command="{prism:GoBack GoBackType=ToRoot}"
+            Margin="10"
+            Grid.Row="2"/>
     <Button Text="Show Alert Dialog"
             Command="{Binding ShowPageDialog}"
             Margin="10"
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.Column="1"/>
   </Grid>
 </ContentPage>

--- a/sample/MauiModule/Views/ViewD.xaml
+++ b/sample/MauiModule/Views/ViewD.xaml
@@ -31,10 +31,10 @@
       </CollectionView.ItemTemplate>
     </CollectionView>
 
-    <!--<Button Text="Go Back" 
+    <Button Text="Go Back" 
             Command="{prism:GoBack}"
             Margin="10"
-            Grid.Row="1" />-->
+            Grid.Row="1" />
     <Button Text="Show Alert Dialog"
             Command="{Binding ShowPageDialog}"
             Margin="10"

--- a/src/Prism.Maui/Navigation/Xaml/GoBackExtension.cs
+++ b/src/Prism.Maui/Navigation/Xaml/GoBackExtension.cs
@@ -20,7 +20,10 @@ public class GoBackExtension : NavigationExtensionBase
             AddKnownNavigationParameters(parameters);
         }
 
-        var result = await navigationService.GoBackToRootAsync(parameters);
+        var result = GoBackType == GoBackType.ToRoot ?
+                await navigationService.GoBackToRootAsync(parameters) :
+                await navigationService.GoBackAsync(parameters);
+
         if (result.Exception != null)
         {
             Log(result.Exception, parameters);

--- a/src/Prism.Maui/Navigation/Xaml/GoBackExtension.cs
+++ b/src/Prism.Maui/Navigation/Xaml/GoBackExtension.cs
@@ -1,0 +1,29 @@
+﻿
+namespace Prism.Navigation.Xaml;
+
+[ContentProperty(nameof(GoBackType))]
+public class GoBackExtension : NavigationExtensionBase
+{
+    public static readonly BindableProperty GoBackTypeProperty =
+        BindableProperty.Create(nameof(GoBackType), typeof(GoBackType), typeof(GoBackExtension), GoBackType.Default);
+
+    public GoBackType GoBackType
+    {
+        get => (GoBackType)GetValue(GoBackTypeProperty);
+        set => SetValue(GoBackTypeProperty, value);
+    }
+
+    protected override async Task HandleNavigation(INavigationParameters parameters, INavigationService navigationService)
+    {
+        if (GoBackType != GoBackType.ToRoot)
+        {
+            AddKnownNavigationParameters(parameters);
+        }
+
+        var result = await navigationService.GoBackToRootAsync(parameters);
+        if (result.Exception != null)
+        {
+            Log(result.Exception, parameters);
+        }
+    }
+}

--- a/src/Prism.Maui/Navigation/Xaml/GoBackType.cs
+++ b/src/Prism.Maui/Navigation/Xaml/GoBackType.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Prism.Navigation.Xaml;
+
+public enum GoBackType
+{
+    Default = 0,
+    ToRoot = 1
+}

--- a/src/Prism.Maui/Navigation/Xaml/NavigateToExtension.cs
+++ b/src/Prism.Maui/Navigation/Xaml/NavigateToExtension.cs
@@ -26,8 +26,6 @@ public class NavigateToExtension : NavigationExtensionBase
 
     protected override void Log(Exception ex, INavigationParameters parameters)
     {
-        //TODO: What to do with logs?
-        //Xamarin.Forms.Internals.Log.Warning("Warning", $"{GetType().Name} threw an exception while navigating to '{Name}'.");
-        //Xamarin.Forms.Internals.Log.Warning("Exception", ex.ToString());
+        // TODO: Determine a good way to log
     }
 }

--- a/src/Prism.Maui/Navigation/Xaml/NavigateToExtension.cs
+++ b/src/Prism.Maui/Navigation/Xaml/NavigateToExtension.cs
@@ -1,0 +1,33 @@
+﻿
+namespace Prism.Navigation.Xaml;
+
+[ContentProperty(nameof(Name))]
+public class NavigateToExtension : NavigationExtensionBase
+{
+    public static readonly BindableProperty NameProperty =
+        BindableProperty.Create(nameof(Name), typeof(string), typeof(NavigateToExtension), null);
+
+    public string Name
+    {
+        get => (string)GetValue(NameProperty);
+        set => SetValue(NameProperty, value);
+    }
+
+    protected override async Task HandleNavigation(INavigationParameters parameters, INavigationService navigationService)
+    {
+        AddKnownNavigationParameters(parameters);
+
+        var result = await navigationService.NavigateAsync(Name, parameters);
+        if (result.Exception != null)
+        {
+            Log(result.Exception, parameters);
+        }
+    }
+
+    protected override void Log(Exception ex, INavigationParameters parameters)
+    {
+        //TODO: What to do with logs?
+        //Xamarin.Forms.Internals.Log.Warning("Warning", $"{GetType().Name} threw an exception while navigating to '{Name}'.");
+        //Xamarin.Forms.Internals.Log.Warning("Exception", ex.ToString());
+    }
+}

--- a/src/Prism.Maui/Navigation/Xaml/NavigationExtensionBase.cs
+++ b/src/Prism.Maui/Navigation/Xaml/NavigationExtensionBase.cs
@@ -1,0 +1,74 @@
+﻿using Prism.Xaml;
+using System.Windows.Input;
+
+namespace Prism.Navigation.Xaml;
+
+public abstract class NavigationExtensionBase : Prism.Xaml.TargetAwareExtensionBase<ICommand>, ICommand
+{
+    public static readonly BindableProperty AnimatedProperty =
+        BindableProperty.Create(nameof(Animated), typeof(bool), typeof(NavigationExtensionBase), true);
+
+    public static readonly BindableProperty UseModalNavigationProperty =
+        BindableProperty.Create(nameof(UseModalNavigation), typeof(bool?), typeof(NavigationExtensionBase), null);
+
+    protected internal bool IsNavigating { get; private set; }
+
+    public bool Animated
+    {
+        get => (bool)GetValue(AnimatedProperty);
+        set => SetValue(AnimatedProperty, value);
+    }
+
+    public bool? UseModalNavigation
+    {
+        get => (bool?)GetValue(UseModalNavigationProperty);
+        set => SetValue(UseModalNavigationProperty, value);
+    }
+
+    public bool CanExecute(object parameter) => !IsNavigating;
+
+    public event EventHandler CanExecuteChanged;
+
+    public async void Execute(object parameter)
+    {
+        var parameters = parameter.ToNavigationParameters(TargetElement);
+
+        IsNavigating = true;
+        try
+        {
+            RaiseCanExecuteChanged();
+
+            var navigationService = Navigation.GetNavigationService(Page);
+            await HandleNavigation(parameters, navigationService);
+        }
+        catch (Exception ex)
+        {
+            Log(ex, parameters);
+        }
+        finally
+        {
+            IsNavigating = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    protected override ICommand ProvideValue(IServiceProvider serviceProvider) =>
+        this;
+
+    protected virtual void Log(Exception ex, INavigationParameters parameters)
+    {
+        //TODO: What to do with logs?
+        //Xamarin.Forms.Internals.Log.Warning("Warning", $"{GetType().Name} threw an exception");
+        //Xamarin.Forms.Internals.Log.Warning("Exception", ex.ToString());
+    }
+
+    protected abstract Task HandleNavigation(INavigationParameters parameters, INavigationService navigationService);
+
+    protected void RaiseCanExecuteChanged() => CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+
+    protected void AddKnownNavigationParameters(INavigationParameters parameters)
+    {
+        parameters.Add(KnownNavigationParameters.Animated, Animated);
+        parameters.Add(KnownNavigationParameters.UseModalNavigation, UseModalNavigation);
+    }
+}

--- a/src/Prism.Maui/Navigation/Xaml/NavigationExtensionBase.cs
+++ b/src/Prism.Maui/Navigation/Xaml/NavigationExtensionBase.cs
@@ -3,7 +3,7 @@ using System.Windows.Input;
 
 namespace Prism.Navigation.Xaml;
 
-public abstract class NavigationExtensionBase : Prism.Xaml.TargetAwareExtensionBase<ICommand>, ICommand
+public abstract class NavigationExtensionBase : TargetAwareExtensionBase<ICommand>, ICommand
 {
     public static readonly BindableProperty AnimatedProperty =
         BindableProperty.Create(nameof(Animated), typeof(bool), typeof(NavigationExtensionBase), true);

--- a/src/Prism.Maui/Navigation/Xaml/NavigationExtensionBase.cs
+++ b/src/Prism.Maui/Navigation/Xaml/NavigationExtensionBase.cs
@@ -57,9 +57,7 @@ public abstract class NavigationExtensionBase : Prism.Xaml.TargetAwareExtensionB
 
     protected virtual void Log(Exception ex, INavigationParameters parameters)
     {
-        //TODO: What to do with logs?
-        //Xamarin.Forms.Internals.Log.Warning("Warning", $"{GetType().Name} threw an exception");
-        //Xamarin.Forms.Internals.Log.Warning("Exception", ex.ToString());
+        // TODO: Determine a good way to log
     }
 
     protected abstract Task HandleNavigation(INavigationParameters parameters, INavigationService navigationService);

--- a/src/Prism.Maui/Services/Dialogs/KnownDialogParameters.cs
+++ b/src/Prism.Maui/Services/Dialogs/KnownDialogParameters.cs
@@ -1,0 +1,9 @@
+﻿
+namespace Prism.Services.Dialogs;
+
+public static class KnownDialogParameters
+{
+    public const string CloseOnBackgroundTapped = "closeOnBackgroundTapped";
+
+    public const string XamlParam = "xamlParam";
+}

--- a/src/Prism.Maui/Xaml/Parameter.cs
+++ b/src/Prism.Maui/Xaml/Parameter.cs
@@ -1,0 +1,16 @@
+﻿
+namespace Prism.Xaml;
+
+public class Parameter : BindableObject
+{
+    public string Key { get; set; }
+
+    public static readonly BindableProperty ValueProperty =
+        BindableProperty.Create(nameof(Value), typeof(object), typeof(Parameter));
+
+    public object Value
+    {
+        get => GetValue(ValueProperty);
+        set => SetValue(ValueProperty, value);
+    }
+}

--- a/src/Prism.Maui/Xaml/ParameterExtension.cs
+++ b/src/Prism.Maui/Xaml/ParameterExtension.cs
@@ -1,0 +1,24 @@
+﻿
+namespace Prism.Xaml;
+
+/// <summary>
+/// XAML Extension for INavigation and IDialog parameters
+/// </summary>
+public class ParameterExtension : Parameter, IMarkupExtension<Parameter>
+{
+    /// <summary>
+    /// Method to retrieve value for parameter
+    /// </summary>
+    /// <param name="serviceProvider">The service that supplies the parameters value</param>
+    /// <returns>The instance of the ParameterExtension class</returns>
+    public Parameter ProvideValue(IServiceProvider serviceProvider) =>
+        this;
+
+    /// <summary>
+    /// Method to retrieve value for parameter
+    /// </summary>
+    /// <param name="serviceProvider">The service that supplies the parameters value</param>
+    /// <returns>The return value from <see cref="ProvideValue(IServiceProvider)"/></returns>
+    object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider) =>
+        ProvideValue(serviceProvider);
+}

--- a/src/Prism.Maui/Xaml/ParameterExtensions.cs
+++ b/src/Prism.Maui/Xaml/ParameterExtensions.cs
@@ -1,0 +1,43 @@
+﻿using Prism.Navigation;
+using Prism.Services.Dialogs;
+
+namespace Prism.Xaml;
+
+internal static class ParameterExtensions
+{
+    public static INavigationParameters ToNavigationParameters(this object parameter, BindableObject parent)
+    {
+        parameter = parameter ?? new NavigationParameters();
+        switch (parameter)
+        {
+            case INavigationParameters parameters:
+                return parameters;
+            case Parameter xamlParameter:
+                xamlParameter.BindingContext = xamlParameter.BindingContext ?? parent.BindingContext;
+                return new NavigationParameters { { xamlParameter.Key, xamlParameter.Value } };
+            case Parameters xamlParameters:
+                xamlParameters.BindingContext = xamlParameters.BindingContext ?? parent.BindingContext;
+                return xamlParameters.ToParameters<NavigationParameters>(parent);
+            default:
+                return new NavigationParameters { { KnownNavigationParameters.XamlParam, parameter } };
+        }
+    }
+
+    public static IDialogParameters ToDialogParameters(this object parameter, BindableObject parent)
+    {
+        parameter = parameter ?? new DialogParameters();
+        switch (parameter)
+        {
+            case IDialogParameters parameters:
+                return parameters;
+            case Parameter xamlParameter:
+                xamlParameter.BindingContext = xamlParameter.BindingContext ?? parent.BindingContext;
+                return new DialogParameters { { xamlParameter.Key, xamlParameter.Value } };
+            case Parameters xamlParameters:
+                xamlParameters.BindingContext = xamlParameters.BindingContext ?? parent.BindingContext;
+                return xamlParameters.ToParameters<DialogParameters>(parent);
+            default:
+                return new DialogParameters { { KnownDialogParameters.XamlParam, parameter } };
+        }
+    }
+}

--- a/src/Prism.Maui/Xaml/Parameters.cs
+++ b/src/Prism.Maui/Xaml/Parameters.cs
@@ -1,0 +1,110 @@
+﻿using System.Collections;
+
+namespace Prism.Xaml;
+
+public class Parameters : BindableObject, IList<Parameter>
+{
+    public static readonly BindableProperty ItemsSourceProperty =
+        BindableProperty.Create(nameof(ItemsSource), typeof(IDictionary), typeof(Parameters), null, propertyChanged: OnItemsSourceChanged);
+
+    private static void OnItemsSourceChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is Parameters parameters)
+        {
+            parameters.Clear();
+            foreach (KeyValuePair<string, object> item in parameters.ItemsSource)
+            {
+                parameters.Add(new Parameter { Key = item.Key, Value = item.Value });
+            }
+        }
+    }
+
+    public static readonly BindableProperty ParentProperty = BindableProperty.Create(nameof(Parent),
+        typeof(BindableObject),
+        typeof(Parameters),
+        default(BindableObject), propertyChanged: OnParentPropertyChanged);
+
+    private readonly IList<Parameter> _list = new List<Parameter>();
+
+    public IDictionary ItemsSource
+    {
+        get => (IDictionary)GetValue(ItemsSourceProperty);
+        set => SetValue(ItemsSourceProperty, value);
+    }
+
+    /// <summary>
+    ///     Navigation Parameter Parent. This is a bindable property.
+    /// </summary>
+    /// <remarks>This is used to set the BindingContext of the CommandParameters to the BindingContext of it's parent.</remarks>
+    public BindableObject Parent
+    {
+        get => (BindableObject)GetValue(ParentProperty);
+        set => SetValue(ParentProperty, value);
+    }
+
+    public void Add(Parameter item) => _list.Add(item);
+
+    public void Clear() => _list.Clear();
+
+    public bool Contains(Parameter item) => _list.Contains(item);
+
+    public void CopyTo(Parameter[] array, int arrayIndex) => _list.CopyTo(array, arrayIndex);
+
+    public int Count => _list.Count;
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public IEnumerator<Parameter> GetEnumerator() => _list.GetEnumerator();
+
+    public int IndexOf(Parameter item) => _list.IndexOf(item);
+
+    public void Insert(int index, Parameter item) => _list.Insert(index, item);
+
+    public bool IsReadOnly => _list.IsReadOnly;
+
+    public Parameter this[int index]
+    {
+        get => _list[index];
+        set => _list[index] = value;
+    }
+
+    public bool Remove(Parameter item) => _list.Remove(item);
+
+    public void RemoveAt(int index) => _list.RemoveAt(index);
+
+    public T ToParameters<T>(BindableObject parent)
+        where T : Common.ParametersBase
+    {
+        Parent = Parent ?? parent;
+        var parameters = (T)Activator.CreateInstance(typeof(T));
+        parameters.FromParameters(_list.Select(x => new KeyValuePair<string, object>(x.Key, x.Value)));
+
+        return parameters;
+    }
+
+    private static void OnParentPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+    {
+        if (oldvalue == newvalue) return;
+
+        var self = (Parameters)bindable;
+        if (oldvalue is BindableObject oldParent)
+            oldParent.BindingContextChanged -= BindingContextChanged;
+
+        if (newvalue is BindableObject newParent)
+            newParent.BindingContextChanged += BindingContextChanged;
+
+        void BindingContextChanged(object parentObject, EventArgs args)
+        {
+            var parent = (BindableObject)parentObject;
+            self.BindingContext = parent?.BindingContext;
+        }
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        foreach (var param in this)
+        {
+            param.BindingContext = BindingContext;
+        }
+    }
+}

--- a/src/Prism.Maui/Xaml/TargetAwareExtensionBase.cs
+++ b/src/Prism.Maui/Xaml/TargetAwareExtensionBase.cs
@@ -1,5 +1,4 @@
-﻿using System.Windows.Input;
-using Prism.Behaviors;
+﻿using Prism.Behaviors;
 using Prism.Extensions;
 using Prism.Ioc;
 using Prism.Navigation.Xaml;

--- a/tests/Prism.Maui.Tests/Fixtures/Navigation/Xaml/GoBackExtensionFixture.cs
+++ b/tests/Prism.Maui.Tests/Fixtures/Navigation/Xaml/GoBackExtensionFixture.cs
@@ -1,0 +1,184 @@
+﻿
+using Microsoft.Maui.Controls;
+using Moq;
+using Prism.Common;
+using Prism.Maui.Tests.Mocks.Ioc;
+using Prism.Maui.Tests.Mocks.ViewModels;
+using Prism.Maui.Tests.Mocks.Views;
+using Prism.Navigation.Xaml;
+using System;
+
+namespace Prism.Maui.Tests.Fixtures.Navigation.Xaml;
+
+public class GoBackExtensionFixture
+{
+    [Fact]
+    public void Execute_GoBackTypeDefault_GoesBackAPage()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new GoBackExtension();
+        extension.Page = page;
+
+        extension.Execute(default);
+
+        Mock.Get(mockNavigation)
+            .Verify(x => x.GoBackAsync(It.IsAny<INavigationParameters>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, null)]
+    [InlineData(false, null)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public void Execute_GoBackTypeDefault_NavigationParameters_HasKnownNavigationParameters(bool animated, bool? useModalNavigation)
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        INavigationParameters parameters = default;
+        Mock.Get(mockNavigation)
+            .Setup(x => x.GoBackAsync(It.IsAny<INavigationParameters>()))
+            .Callback<INavigationParameters>(navParameters =>
+            {
+                parameters = navParameters;
+            })
+            .ReturnsAsync(new NavigationResult { Success = false, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new GoBackExtension();
+        extension.Page = page;
+        extension.Animated = animated;
+        extension.UseModalNavigation = useModalNavigation;
+
+        extension.Execute(default);
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.Animated));
+        Assert.Equal(animated, parameters.GetValue<bool>(KnownNavigationParameters.Animated));
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.UseModalNavigation));
+        Assert.Equal(useModalNavigation, parameters.GetValue<bool?>(KnownNavigationParameters.UseModalNavigation));
+    }
+
+    [Fact]
+    public void Execute_GoBackTypeToRoot_GoesBackToRoot()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new GoBackExtension();
+        extension.Page = page;
+        extension.GoBackType = GoBackType.ToRoot;
+
+        extension.Execute(default);
+
+        Mock.Get(mockNavigation)
+            .Verify(x => x.GoBackToRootAsync(It.IsAny<INavigationParameters>()), Times.Once);
+    }
+
+    [Fact]
+    public void Execute_GoBackTypeToRoot_NavigationParameters_DoNotHaveKnownNavigationParameters()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        INavigationParameters parameters = default;
+        Mock.Get(mockNavigation)
+            .Setup(x => x.GoBackToRootAsync(It.IsAny<INavigationParameters>()))
+            .Callback<INavigationParameters>(navParameters =>
+            {
+                parameters = navParameters;
+            })
+            .ReturnsAsync(new NavigationResult { Success = false, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new GoBackExtension();
+        extension.Page = page;
+        extension.GoBackType = GoBackType.ToRoot;
+
+        extension.Execute(default);
+
+        Assert.False(parameters.ContainsKey(KnownNavigationParameters.Animated));
+        Assert.False(parameters.ContainsKey(KnownNavigationParameters.UseModalNavigation));
+    }
+
+    [Fact]
+    public void Execute_GoBackTypeDefault_CommandParameter_IncludedInNavigationParameters()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        INavigationParameters parameters = default;
+        Mock.Get(mockNavigation)
+            .Setup(x => x.GoBackAsync(It.IsAny<INavigationParameters>()))
+            .Callback<INavigationParameters>(navParameters =>
+            {
+                parameters = navParameters;
+            })
+            .ReturnsAsync(new NavigationResult { Success = true, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new GoBackExtension();
+        extension.Page = page;
+
+        extension.Execute("command parameter");
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.XamlParam));
+        Assert.Equal("command parameter", parameters.GetValue<string>(KnownNavigationParameters.XamlParam));
+    }
+
+    [Fact]
+    public void Execute_GoBackTypeToRoot_CommandParameter_IncludedInNavigationParameters()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        INavigationParameters parameters = default;
+        Mock.Get(mockNavigation)
+            .Setup(x => x.GoBackToRootAsync(It.IsAny<INavigationParameters>()))
+            .Callback<INavigationParameters>(navParameters =>
+            {
+                parameters = navParameters;
+            })
+            .ReturnsAsync(new NavigationResult { Success = true, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new GoBackExtension();
+        extension.Page = page;
+        extension.GoBackType = GoBackType.ToRoot;
+
+        extension.Execute("command parameter");
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.XamlParam));
+        Assert.Equal("command parameter", parameters.GetValue<string>(KnownNavigationParameters.XamlParam));
+    }
+}

--- a/tests/Prism.Maui.Tests/Fixtures/Navigation/Xaml/NavigateToExtensionFixture.cs
+++ b/tests/Prism.Maui.Tests/Fixtures/Navigation/Xaml/NavigateToExtensionFixture.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.Maui.Controls;
+using Moq;
+using Prism.Common;
+using Prism.Maui.Tests.Mocks.Ioc;
+using Prism.Maui.Tests.Mocks.ViewModels;
+using Prism.Maui.Tests.Mocks.Views;
+using Prism.Navigation.Xaml;
+using System;
+
+namespace Prism.Maui.Tests.Fixtures.Navigation.Xaml;
+
+public class NavigateToExtensionFixture
+{
+    [Fact]
+    public void Execute_NameIsNull_DoesNotNavigateToPage()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new NavigateToExtension();
+        extension.Page = page;
+
+        var ex = Record.Exception(() => extension.Execute(default));
+
+        Mock.Get(mockNavigation)
+            .Verify(x => x.NavigateAsync(It.IsAny<Uri>(), It.IsAny<INavigationParameters>()), Times.Never);
+    }
+
+    [Fact]
+    public void Execute_NameIsSet_NavigatesToPage()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        Mock.Get(mockNavigation)
+            .Setup(x => x.NavigateAsync(It.IsAny<Uri>(), It.IsAny<INavigationParameters>()))
+            .ReturnsAsync(new NavigationResult { Success = true, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new NavigateToExtension();
+        extension.Page = page;
+        extension.Name = "ViewA";
+
+        extension.Execute(default);
+
+        Mock.Get(mockNavigation)
+            .Verify(x => x.NavigateAsync(It.Is<Uri>(uri => uri.OriginalString == "ViewA"), It.IsAny<INavigationParameters>()), Times.Once);
+    }
+
+    [Theory]
+    [InlineData(true, null)]
+    [InlineData(false, null)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public void Execute_NavigationParameters_HasKnownNavigationParameters(bool animated, bool? useModalNavigation)
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        INavigationParameters parameters = default;
+        Mock.Get(mockNavigation)
+            .Setup(x => x.NavigateAsync(It.IsAny<Uri>(), It.IsAny<INavigationParameters>()))
+            .Callback<Uri, INavigationParameters>((uri, navParameters) =>
+            {
+                parameters = navParameters;
+            })
+            .ReturnsAsync(new NavigationResult { Success = false, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new NavigateToExtension();
+        extension.Page = page;
+        extension.Name = "ViewA";
+        extension.Animated = animated;
+        extension.UseModalNavigation = useModalNavigation;
+
+        extension.Execute(default);
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.Animated));
+        Assert.Equal(animated, parameters.GetValue<bool>(KnownNavigationParameters.Animated));
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.UseModalNavigation));
+        Assert.Equal(useModalNavigation, parameters.GetValue<bool?>(KnownNavigationParameters.UseModalNavigation));
+    }
+
+    [Fact]
+    public void Execute_CommandParameter_IncludedInNavigationParameters()
+    {
+        var mockNavigation = Mock.Of<INavigationService>();
+        var container = new TestContainer();
+        container.RegisterInstance(mockNavigation);
+        container.RegisterInstance(new PageAccessor());
+        container.RegisterForNavigation<PageMock, PageMockViewModel>();
+
+        INavigationParameters parameters = default;
+        Mock.Get(mockNavigation)
+            .Setup(x => x.NavigateAsync(It.IsAny<Uri>(), It.IsAny<INavigationParameters>()))
+            .Callback<Uri, INavigationParameters>((uri, navParameters) =>
+            {
+                parameters = navParameters;
+            })
+            .ReturnsAsync(new NavigationResult { Success = true, Exception = null });
+
+        var registry = container.Resolve<NavigationRegistry>();
+        var page = registry.CreateView(container, "PageMock") as Page;
+        var extension = new NavigateToExtension();
+        extension.Page = page;
+        extension.Name = "ViewA";
+
+        extension.Execute("command parameter");
+
+        Assert.True(parameters.ContainsKey(KnownNavigationParameters.XamlParam));
+        Assert.Equal("command parameter", parameters.GetValue<string>(KnownNavigationParameters.XamlParam));
+    }
+}


### PR DESCRIPTION
# Description
Brings over the the XAML navigation extensions from Prism.Forms

- Closes #22 