### PR TITLE
move Modal Popping event handler to window

### DIFF
--- a/src/Prism.Maui/Navigation/PrismWindow.cs
+++ b/src/Prism.Maui/Navigation/PrismWindow.cs
@@ -7,7 +7,18 @@ internal class PrismWindow : Window
     public PrismWindow(string name = DefaultWindowName)
     {
         Name = name;
+        ModalPopping += PrismApplication_ModalPopping;
     }
 
     public string Name { get; }
+
+    private async void PrismApplication_ModalPopping(object sender, ModalPoppingEventArgs e)
+    {
+        if (PageNavigationService.NavigationSource == PageNavigationSource.NavigationService)
+            return;
+
+        e.Cancel = true;
+        var navService = Xaml.Navigation.GetNavigationService(e.Modal);
+        await navService.GoBackAsync();
+    }
 }

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -75,12 +75,12 @@ public abstract class PrismAppBuilder
         containerExtension.RegisterInstance(this);
         containerExtension.RegisterSingleton<IMauiInitializeService, PrismInitializationService>();
 
-        ConfigureViewModelLocator(containerExtension);
+        ConfigureViewModelLocator();
     }
 
     public MauiAppBuilder MauiBuilder { get; }
 
-    private void ConfigureViewModelLocator(IContainerProvider container)
+    private void ConfigureViewModelLocator()
     {
         ViewModelLocationProvider2.SetDefaultViewToViewModelTypeResolver(view =>
         {

--- a/src/Prism.Maui/PrismApplication.cs
+++ b/src/Prism.Maui/PrismApplication.cs
@@ -20,17 +20,6 @@ public abstract class PrismApplication : Application, ILegacyPrismApplication
         _containerExtension = ContainerLocator.Current;
         RegisterTypes(_containerExtension);
         NavigationService = Container.Resolve<INavigationService>((typeof(IApplication), this));
-        this.ModalPopping += PrismApplication_ModalPopping;
-    }
-
-    private async void PrismApplication_ModalPopping(object sender, ModalPoppingEventArgs e)
-    {
-        if (PageNavigationService.NavigationSource == PageNavigationSource.NavigationService)
-            return;
-
-        e.Cancel = true;
-        var navService = Navigation.Xaml.Navigation.GetNavigationService(e.Modal);
-        await navService.GoBackAsync();
     }
 
     void ILegacyPrismApplication.OnInitialized() => OnInitialized();


### PR DESCRIPTION
# Description

MAUI sends Modal Push/Pop events to the Application via the Window. Since we already force the use of the PrismWindow it makes more sense to handle this in the Window and completely eliminate any requirements for PrismApplication besides making it easier for Legacy migrations.