### PR TITLE
Adding the Dialog Service

### DIFF
--- a/sample/MauiModule/Dialogs/LoginDialog.xaml
+++ b/sample/MauiModule/Dialogs/LoginDialog.xaml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Grid xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+      xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+      xmlns:vm="clr-namespace:MauiModule.ViewModels"
+      x:DataType="vm:LoginViewModel"
+      BackgroundColor="White"
+      RowDefinitions="Auto,*"
+      x:Class="MauiModule.Dialogs.LoginDialog">
+  <BoxView Color="Black" />
+  <Label Text="{Binding Title}"
+         HorizontalTextAlignment="Center"
+         TextColor="White"
+         Margin="0,8" />
+  <VerticalStackLayout Grid.Row="1"
+                       Padding="10,3,10,10">
+    <Label Text="Enter your name" />
+    <Entry Text="{Binding Name}"
+           Placeholder="John Doe"
+           WidthRequest="200"
+           PlaceholderColor="LightGray" />
+    <Button Text="Submit"
+            HorizontalOptions="Center"
+            Command="{Binding LoginCommand}" />
+  </VerticalStackLayout>
+</Grid>

--- a/sample/MauiModule/Dialogs/LoginDialog.xaml.cs
+++ b/sample/MauiModule/Dialogs/LoginDialog.xaml.cs
@@ -1,0 +1,9 @@
+namespace MauiModule.Dialogs;
+
+public partial class LoginDialog : Grid
+{
+    public LoginDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/sample/MauiModule/MauiAppModule.cs
+++ b/sample/MauiModule/MauiAppModule.cs
@@ -1,4 +1,5 @@
-﻿using MauiModule.ViewModels;
+﻿using MauiModule.Dialogs;
+using MauiModule.ViewModels;
 using MauiModule.Views;
 
 namespace MauiModule
@@ -13,6 +14,7 @@ namespace MauiModule
 
         public void RegisterTypes(IContainerRegistry containerRegistry)
         {
+            containerRegistry.RegisterDialog<LoginDialog, LoginViewModel>();
             containerRegistry.RegisterForNavigation<ViewA, ViewAViewModel>();
             containerRegistry.RegisterForNavigation<ViewB, ViewBViewModel>();
             containerRegistry.RegisterForNavigation<ViewC, ViewCViewModel>();

--- a/sample/MauiModule/ViewModels/BaseServices.cs
+++ b/sample/MauiModule/ViewModels/BaseServices.cs
@@ -2,12 +2,20 @@
 
 public class BaseServices
 {
-    public BaseServices(INavigationService navigationService, IPageDialogService pageDialogs)
+    public BaseServices(
+        INavigationService navigationService,
+        IPageDialogService pageDialogs,
+        IDialogService dialogService,
+        IDialogViewRegistry dialogRegistry)
     {
         NavigationService = navigationService;
         PageDialogs = pageDialogs;
+        Dialogs = dialogService;
+        DialogRegistry = dialogRegistry;
     }
 
     public INavigationService NavigationService { get; }
     public IPageDialogService PageDialogs { get; }
+    public IDialogService Dialogs { get; }
+    public IDialogViewRegistry DialogRegistry { get; }
 }

--- a/sample/MauiModule/ViewModels/LoginViewModel.cs
+++ b/sample/MauiModule/ViewModels/LoginViewModel.cs
@@ -1,0 +1,42 @@
+﻿namespace MauiModule.ViewModels;
+
+public class LoginViewModel : BindableBase, IDialogAware
+{
+    private bool _canClose;
+
+    public LoginViewModel()
+    {
+        LoginCommand = new DelegateCommand(OnLoginCommandExecuted);
+    }
+
+    public string Title => "What's your name?";
+
+    private string _name;
+    public string Name
+    {
+        get => _name;
+        set => SetProperty(ref _name, value);
+    }
+
+    public DelegateCommand LoginCommand { get; }
+
+    public DialogCloseEvent RequestClose { get; set; }
+
+    //public event Action<IDialogParameters> RequestClose;
+
+    public bool CanCloseDialog() => _canClose;
+
+    public void OnDialogClosed()
+    {
+    }
+
+    public void OnDialogOpened(IDialogParameters parameters)
+    {
+    }
+
+    private void OnLoginCommandExecuted()
+    {
+        _canClose = true;
+        RequestClose.Invoke();
+    }
+}

--- a/sample/MauiModule/ViewModels/ViewModelBase.cs
+++ b/sample/MauiModule/ViewModels/ViewModelBase.cs
@@ -7,11 +7,13 @@ public abstract class ViewModelBase : BindableBase, IInitialize, INavigatedAware
 {
     protected INavigationService _navigationService { get; }
     protected IPageDialogService _pageDialogs { get; }
+    protected IDialogService _dialogs { get; }
 
     protected ViewModelBase(BaseServices baseServices)
     {
         _navigationService = baseServices.NavigationService;
         _pageDialogs = baseServices.PageDialogs;
+        _dialogs = baseServices.Dialogs;
         Title = Regex.Replace(GetType().Name, "ViewModel", string.Empty);
         Id = Guid.NewGuid().ToString();
         NavigateCommand = new DelegateCommand<string>(OnNavigateCommandExecuted);
@@ -22,17 +24,33 @@ public abstract class ViewModelBase : BindableBase, IInitialize, INavigatedAware
             foreach (string message in args.NewItems)
                 Console.WriteLine($"{Title} - {message}");
         };
+
+        AvailableDialogs = baseServices.DialogRegistry.Registrations.Select(x => x.Name).ToList();
+        SelectedDialog = AvailableDialogs.FirstOrDefault();
+        ShowDialog = new DelegateCommand(OnShowDialogCommand, () => !string.IsNullOrEmpty(SelectedDialog))
+            .ObservesProperty(() => SelectedDialog);
     }
+
+    public IEnumerable<string> AvailableDialogs { get; }
 
     public string Title { get; }
 
     public string Id { get; }
+
+    private string _selectedDialog;
+    public string SelectedDialog
+    {
+        get => _selectedDialog;
+        set => SetProperty(ref _selectedDialog, value);
+    }
 
     public ObservableCollection<string> Messages { get; }
 
     public DelegateCommand<string> NavigateCommand { get; }
 
     public DelegateCommand ShowPageDialog { get; }
+
+    public DelegateCommand ShowDialog { get; }
 
     private void OnNavigateCommandExecuted(string uri)
     {
@@ -46,6 +64,15 @@ public abstract class ViewModelBase : BindableBase, IInitialize, INavigatedAware
         Messages.Add("OnShowPageDialog");
         _pageDialogs.DisplayAlertAsync("Message", $"Hello from {Title}. This is a Page Dialog Service Alert!", "Ok");
     }
+
+    private void OnShowDialogCommand()
+    {
+        Messages.Add("OnShowDialog");
+        _dialogs.ShowDialog(SelectedDialog, null, DialogCallback);
+    }
+
+    private void DialogCallback(IDialogResult result) =>
+        Messages.Add("Dialog Closed");
 
     public void Initialize(INavigationParameters parameters)
     {

--- a/sample/MauiModule/Views/ViewD.xaml
+++ b/sample/MauiModule/Views/ViewD.xaml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:loc="clr-namespace:MauiModule.ViewModels"
              xmlns:prism="http://prismlibrary.com"
              x:Class="MauiModule.Views.ViewD"
+             x:DataType="loc:ViewModelBase"
              Title="{Binding Title}"
              BackgroundColor="White">
-  <Grid RowDefinitions="*,Auto,Auto"
+  <Grid RowDefinitions="*,Auto,Auto,Auto"
         ColumnDefinitions="*,*">
     <CollectionView ItemsSource="{Binding Messages}"
                     Grid.ColumnSpan="2">
@@ -31,18 +33,29 @@
       </CollectionView.ItemTemplate>
     </CollectionView>
 
-    <Button Text="Go Back" 
+    <Picker ItemsSource="{Binding AvailableDialogs}"
+            SelectedItem="{Binding SelectedDialog}"
+            BackgroundColor="White"
+            Margin="10"
+            Grid.Row="1"
+            Grid.ColumnSpan="2" />
+    <Button Text="Go Back"
             Command="{prism:GoBack}"
             Margin="10"
-            Grid.Row="1" />
+            Grid.Row="2" />
+    <Button Text="Show Dialog"
+            Command="{Binding ShowDialog}"
+            Margin="10"
+            Grid.Row="2"
+            Grid.Column="1"/>
     <Button Text="Go Back To Root"
             Command="{prism:GoBack GoBackType=ToRoot}"
             Margin="10"
-            Grid.Row="2"/>
+            Grid.Row="3"/>
     <Button Text="Show Alert Dialog"
             Command="{Binding ShowPageDialog}"
             Margin="10"
-            Grid.Row="2"
+            Grid.Row="3"
             Grid.Column="1"/>
   </Grid>
 </ContentPage>

--- a/src/Prism.Maui/Common/UriParsingHelper.cs
+++ b/src/Prism.Maui/Common/UriParsingHelper.cs
@@ -1,5 +1,5 @@
 ﻿using Prism.Navigation;
-using Prism.Services.Dialogs;
+using Prism.Services;
 
 namespace Prism.Common;
 

--- a/src/Prism.Maui/Ioc/DialogRegistrationExtensions.cs
+++ b/src/Prism.Maui/Ioc/DialogRegistrationExtensions.cs
@@ -1,0 +1,71 @@
+﻿using Prism.Common;
+using Prism.Services;
+
+namespace Prism.Ioc;
+
+public static class DialogRegistrationExtensions
+{
+    public static IContainerRegistry RegisterDialog<TView>(this IContainerRegistry containerRegistry, string name = null)
+            where TView : View =>
+        containerRegistry.RegisterDialog(typeof(TView), null, name);
+
+    public static IContainerRegistry RegisterDialog<TView, TViewModel>(this IContainerRegistry containerRegistry, string name = null)
+        where TView : View =>
+        containerRegistry.RegisterDialog(typeof(TView), typeof(TViewModel), name);
+
+    public static IContainerRegistry RegisterDialog(this IContainerRegistry container, Type view, Type viewModel, string name = null)
+    {
+        container.RegisterInstance(GetViewRegistration(view, viewModel, name))
+            .Register(view);
+
+        if (viewModel != null)
+            container.Register(viewModel);
+        return container;
+    }
+
+    public static IContainerRegistry RegisterDialogContainer<T>(this IContainerRegistry container)
+        where T : class, IDialogContainer =>
+        container.Register<IDialogContainer, T>();
+
+    public static IServiceCollection RegisterDialog<TView>(this IServiceCollection services, string name = null)
+            where TView : View =>
+        services.RegisterDialog(typeof(TView), null, name);
+
+    public static IServiceCollection RegisterDialog<TView, TViewModel>(this IServiceCollection services, string name = null)
+        where TView : View =>
+        services.RegisterDialog(typeof(TView), typeof(TViewModel), name);
+
+    public static IServiceCollection RegisterDialog(this IServiceCollection services, Type view, Type viewModel, string name = null)
+    {
+        services.AddSingleton(GetViewRegistration(view, viewModel, name))
+            .AddTransient(view);
+
+        if (viewModel != null)
+            services.AddTransient(viewModel);
+        return services;
+    }
+
+    public static IServiceCollection RegisterDialogContainer<T>(this IServiceCollection services)
+        where T : class, IDialogContainer =>
+        services.AddTransient<IDialogContainer, T>();
+
+    private static ViewRegistration GetViewRegistration(Type view, Type viewModel, string name)
+    {
+        if (view is null)
+            throw new ArgumentNullException(nameof(view));
+
+        if (!view.IsAssignableTo(typeof(View)))
+            throw new InvalidOperationException($"The Dialog '{view.FullName}' must inherit from Microsoft.Maui.Controls.View");
+
+        if (string.IsNullOrEmpty(name))
+            name = view.Name;
+
+        return new ViewRegistration
+        {
+            Type = ViewType.Dialog,
+            Name = name,
+            View = view,
+            ViewModel = viewModel
+        };
+    }
+}

--- a/src/Prism.Maui/Navigation/PageNavigationSource.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationSource.cs
@@ -3,5 +3,6 @@
 public enum PageNavigationSource
 {
     NavigationService,
-    Device
+    Device,
+    DialogService
 }

--- a/src/Prism.Maui/Navigation/PrismWindow.cs
+++ b/src/Prism.Maui/Navigation/PrismWindow.cs
@@ -21,12 +21,12 @@ internal class PrismWindow : Window
 
     private async void PrismWindow_ModalPopping(object sender, ModalPoppingEventArgs e)
     {
-        if (PageNavigationService.NavigationSource == PageNavigationSource.NavigationService)
-            return;
-
-        e.Cancel = true;
-        var navService = Xaml.Navigation.GetNavigationService(e.Modal);
-        await navService.GoBackAsync();
+        if (PageNavigationService.NavigationSource == PageNavigationSource.Device)
+        {
+            e.Cancel = true;
+            var navService = Xaml.Navigation.GetNavigationService(e.Modal);
+            await navService.GoBackAsync();
+        }
     }
 
     protected override void OnActivated()

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -63,9 +63,18 @@ public abstract class PrismAppBuilder
                         return true;
 
                     var window = windows.First(x => x.IsActive);
-                    var container = window.CurrentPage.GetContainerProvider();
-                    var navigation = container.Resolve<INavigationService>();
-                    navigation.GoBackAsync();
+                    var currentPage = window.CurrentPage;
+                    var container = currentPage.GetContainerProvider();
+                    if(currentPage is IDialogContainer dialogContainer)
+                    {
+                        if (dialogContainer.Dismiss.CanExecute(null))
+                            dialogContainer.Dismiss.Execute(null);
+                    }
+                    else
+                    {
+                        var navigation = container.Resolve<INavigationService>();
+                        navigation.GoBackAsync();
+                    }
 
                     return false;
                 });
@@ -211,7 +220,9 @@ public abstract class PrismAppBuilder
         containerRegistry.RegisterSingleton<IEventAggregator, EventAggregator>();
         containerRegistry.RegisterSingleton<IKeyboardMapper, KeyboardMapper>();
         containerRegistry.RegisterScoped<IPageDialogService, PageDialogService>();
-        //containerRegistry.RegisterSingleton<IDialogService, DialogService>();
+        containerRegistry.RegisterScoped<IDialogService, DialogService>();
+        containerRegistry.Register<IDialogViewRegistry, DialogViewRegistry>();
+        containerRegistry.RegisterDialogContainer<DialogContainerPage>();
         //containerRegistry.RegisterSingleton<IDeviceService, DeviceService>();
         containerRegistry.RegisterScoped<IPageAccessor, PageAccessor>();
         containerRegistry.RegisterScoped<INavigationService, PageNavigationService>();

--- a/src/Prism.Maui/Services/Dialogs/DialogCallback.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogCallback.cs
@@ -1,0 +1,50 @@
+﻿namespace Prism.Services;
+
+public readonly struct DialogCallback
+{
+    private MulticastDelegate _callback { get; }
+    
+    internal DialogCallback(MulticastDelegate callback)
+    {
+        _callback = callback;
+    }
+
+    internal Task Invoke(Exception ex) =>
+        Invoke(new DialogResult { Exception = ex });
+
+    internal async Task Invoke(IDialogResult result)
+    {
+        if (_callback is null)
+            return;
+        else if (_callback is Action action)
+            action();
+        else if (_callback is Action<IDialogResult> actionResult)
+            actionResult(result);
+        else if (_callback is Action<Exception> actionError && result.Exception is not null)
+            actionError(result.Exception);
+        else if (_callback is Func<Task> func)
+            await func();
+        else if (_callback is Func<IDialogResult, Task> funcResult)
+            await funcResult(result);
+        else if(_callback is Func<Exception, Task> funcError && result.Exception is not null)
+            await funcError(result.Exception);
+    }
+
+    public static DialogCallback OnClose(Action action) =>
+        new (action);
+
+    public static DialogCallback OnClose(Action<IDialogResult> action) =>
+        new (action);
+
+    public static DialogCallback OnError(Action<Exception> action) =>
+        new (action);
+
+    public static DialogCallback OnCloseAsync(Func<Task> func) =>
+        new(func);
+
+    public static DialogCallback OnCloseAsync(Func<IDialogResult, Task> func) =>
+        new(func);
+
+    public static DialogCallback OnErrorAsync(Func<Exception, Task> func) =>
+        new(func);
+}

--- a/src/Prism.Maui/Services/Dialogs/DialogCloseEvent.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogCloseEvent.cs
@@ -1,0 +1,43 @@
+using System.ComponentModel;
+
+namespace Prism.Services;
+
+public struct DialogCloseEvent
+{
+    private readonly MulticastDelegate _callback;
+
+    public DialogCloseEvent()
+    {
+        _callback = null;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public DialogCloseEvent(Action<IDialogParameters> callback)
+    {
+        _callback = callback;
+    }
+
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public DialogCloseEvent(Func<IDialogParameters, Task> callback)
+    {
+        _callback = callback;
+    }
+
+    public void Invoke() =>
+        Invoke(null);
+
+    public void Invoke(IDialogParameters parameters)
+    {
+        parameters ??= new DialogParameters();
+
+        switch(_callback)
+        {
+            case Action<IDialogParameters> actionCallback:
+                actionCallback(parameters);
+                break;
+            case Func<IDialogParameters, Task> taskCallback:
+                taskCallback(parameters);
+                break;
+        }
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/DialogContainerPage.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogContainerPage.cs
@@ -1,0 +1,175 @@
+﻿using System.ComponentModel;
+using System.Windows.Input;
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+using Microsoft.Maui.Layouts;
+using Prism.Services.Xaml;
+using Application = Microsoft.Maui.Controls.Application;
+using Page = Microsoft.Maui.Controls.Page;
+
+namespace Prism.Services;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+public class DialogContainerPage : ContentPage, IDialogContainer
+{
+    public const string AutomationIdName = "PrismDialogModal";
+
+    public DialogContainerPage()
+    {
+        AutomationId = AutomationIdName;
+        BackgroundColor = Colors.Transparent;
+        On<iOS>().SetModalPresentationStyle(UIModalPresentationStyle.OverFullScreen);
+    }
+
+    public View DialogView { get; private set; }
+
+    public ICommand Dismiss { get; private set; }
+
+    public async Task ConfigureLayout(Page currentPage, View dialogView, bool hideOnBackgroundTapped, ICommand dismissCommand)
+    {
+        Dismiss = dismissCommand;
+        DialogView = dialogView;
+        Content = GetContentLayout(currentPage, dialogView, hideOnBackgroundTapped, dismissCommand);
+
+        await DoPush(currentPage);
+    }
+
+    protected virtual async Task DoPush(Page currentPage)
+    {
+        await currentPage.Navigation.PushModalAsync(this, false);
+    }
+
+    public virtual async Task DoPop(Page currentPage)
+    {
+        await currentPage.Navigation.PopModalAsync(false);
+    }
+
+    protected virtual View GetContentLayout(Page currentPage, View dialogView, bool hideOnBackgroundTapped, ICommand dismissCommand)
+    {
+        var overlay = new AbsoluteLayout();
+        var popupContainer = new DialogContainerView
+        {
+            IsPopupContent = true,
+            HorizontalOptions = LayoutOptions.Center,
+            VerticalOptions = LayoutOptions.Center,
+            Content = dialogView,
+        };
+
+        var relativeWidth = DialogLayout.GetRelativeWidthRequest(dialogView);
+        if (relativeWidth != null)
+        {
+            popupContainer.SetBinding(WidthRequestProperty,
+                new Binding(nameof(Width),
+                            BindingMode.OneWay,
+                            new RelativeContentSizeConverter { RelativeSize = relativeWidth.Value },
+                            source: this));
+        }
+
+        var relativeHeight = DialogLayout.GetRelativeHeightRequest(dialogView);
+        if (relativeHeight != null)
+        {
+            popupContainer.SetBinding(HeightRequestProperty,
+                new Binding(nameof(Height),
+                            BindingMode.OneWay,
+                            new RelativeContentSizeConverter { RelativeSize = relativeHeight.Value },
+                            source: this));
+        }
+
+        AbsoluteLayout.SetLayoutFlags(popupContainer, AbsoluteLayoutFlags.PositionProportional);
+        var popupBounds = DialogLayout.GetLayoutBounds(dialogView);
+        AbsoluteLayout.SetLayoutBounds(popupContainer, popupBounds);
+
+        var useMask = DialogLayout.GetUseMask(popupContainer.Content) ?? true;
+        if (useMask)
+        {
+            var mask = GetMask(currentPage, dialogView, hideOnBackgroundTapped, dismissCommand);
+            AbsoluteLayout.SetLayoutFlags(mask, AbsoluteLayoutFlags.All);
+            AbsoluteLayout.SetLayoutBounds(mask, new Rect(0, 0, 1, 1));
+            overlay.Children.Add(mask);
+        }
+
+        overlay.Children.Add(popupContainer);
+        return overlay;
+    }
+
+    private View GetMask(Page currentPage, View dialogView, bool hideOnBackgroundTapped, ICommand dismissCommand)
+    {
+        View mask = DialogLayout.GetMask(dialogView);
+        var reference = currentPage.GetParentWindow().Page;
+        if (mask is null)
+        {
+            Style overlayStyle = GetOverlayStyle(dialogView, currentPage);
+
+            mask = new BoxView
+            {
+                Style = overlayStyle,
+                //HeightRequest = reference.Height,
+                //WidthRequest = reference.Width
+            };
+        }
+
+        mask.SetBinding(WidthRequestProperty, new Binding
+        {
+            Path = nameof(Width),
+            Source = reference
+        });
+        mask.SetBinding(HeightRequestProperty, new Binding
+        {
+            Path = nameof(Height),
+            Source = reference
+        });
+
+        if (hideOnBackgroundTapped)
+        {
+            mask.GestureRecognizers.Add(new TapGestureRecognizer
+            {
+                Command = dismissCommand
+            });
+        }
+
+        return mask;
+    }
+
+    private Style GetOverlayStyle(View popupView, Page currentPage)
+    {
+        var style = DialogLayout.GetMaskStyle(popupView);
+        if (style != null)
+        {
+            return style;
+        }
+
+        return GetStyle(currentPage);
+    }
+
+    private static Style GetStyle(Element element)
+    {
+        if (element is Page page && page.Resources.ContainsKey(DialogLayout.PopupOverlayStyle) && page.Resources[DialogLayout.PopupOverlayStyle] is Style pageStyle)
+            return pageStyle;
+        else if (element is Application app)
+        {
+            if (app.Resources.ContainsKey(DialogLayout.PopupOverlayStyle) && app.Resources[DialogLayout.PopupOverlayStyle] is Style appStyle)
+                return appStyle;
+
+            var overlayStyle = DefaultStyle();
+
+            app.Resources.Add(DialogLayout.PopupOverlayStyle, overlayStyle);
+            return overlayStyle;
+        }
+        else if (element is Window window && window.Parent is null)
+        {
+            // HACK: https://github.com/dotnet/maui/issues/8635
+            window.Parent = Application.Current;
+            return GetStyle(window.Parent);
+        }
+        else
+            return GetStyle(element.Parent);
+    }
+
+    private static Style DefaultStyle()
+    {
+        var overlayStyle = new Style(typeof(BoxView));
+        overlayStyle.Setters.Add(new Setter { Property = BoxView.OpacityProperty, Value = 0.75 });
+        overlayStyle.Setters.Add(new Setter { Property = BoxView.BackgroundColorProperty, Value = new Color(0, 0, 0, 0x75) });
+        return overlayStyle;
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/DialogContainerView.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogContainerView.cs
@@ -1,0 +1,22 @@
+﻿namespace Prism.Services;
+
+internal class DialogContainerView : ContentView
+{
+    public static readonly BindableProperty IsPageContentProperty =
+        BindableProperty.Create(nameof(IsPageContent), typeof(bool), typeof(DialogContainerView), false);
+
+    public static readonly BindableProperty IsPopupContentProperty =
+        BindableProperty.Create(nameof(IsPopupContent), typeof(bool), typeof(DialogContainerView), false);
+
+    public bool IsPageContent
+    {
+        get => (bool)GetValue(IsPageContentProperty);
+        set => SetValue(IsPageContentProperty, value);
+    }
+
+    public bool IsPopupContent
+    {
+        get => (bool)GetValue(IsPopupContentProperty);
+        set => SetValue(IsPopupContentProperty, value);
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/DialogException.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogException.cs
@@ -1,0 +1,20 @@
+﻿namespace Prism.Services;
+
+public class DialogException : Exception
+{
+    public const string ShowDialog = "Error while displaying dialog";
+
+    public const string RequiresContentPage = "The current page must be a ContentPage";
+
+    public const string HostPageIsNotDialogHost = "The current page is not currently hosting a Dialog";
+
+    public const string CanCloseIsFalse = "CanClose returned false";
+
+    public const string NoViewModel = "No ViewModel could be found";
+
+    public const string ImplementIDialogAware = "The ViewModel does not implement IDialogAware";
+
+    public DialogException(string message) : base(message)
+    {
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/DialogParameters.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogParameters.cs
@@ -1,6 +1,6 @@
 ﻿using Prism.Common;
 
-namespace Prism.Services.Dialogs;
+namespace Prism.Services;
 
 public class DialogParameters : ParametersBase, IDialogParameters
 {

--- a/src/Prism.Maui/Services/Dialogs/DialogResult.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogResult.cs
@@ -1,4 +1,4 @@
-﻿namespace Prism.Services.Dialogs;
+﻿namespace Prism.Services;
 
 public record DialogResult : IDialogResult
 {

--- a/src/Prism.Maui/Services/Dialogs/DialogService.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogService.cs
@@ -1,0 +1,192 @@
+﻿using Prism.Commands;
+using Prism.Common;
+using Prism.Ioc;
+using Prism.Navigation;
+using Prism.Services.Xaml;
+
+namespace Prism.Services;
+
+/// <summary>
+/// Provides the ability to display dialogs from ViewModels.
+/// </summary>
+public sealed class DialogService : IDialogService
+{
+    private readonly IContainerProvider _container;
+    private readonly IPageAccessor _pageAccessor;
+
+    public DialogService(IContainerProvider container, IPageAccessor pageAccessor)
+    {
+        _container = container ?? throw new ArgumentNullException(nameof(container));
+        _pageAccessor = pageAccessor ?? throw new ArgumentNullException(nameof(pageAccessor));
+    }
+
+    public void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback)
+    {
+        ShowDialogInternal(name, parameters, callback);
+    }
+
+    public void ShowDialog(string name, IDialogParameters parameters, Func<IDialogResult, Task> callback)
+    {
+        ShowDialogInternal(name, parameters, callback);
+    }
+
+    private void ShowDialogInternal(string name, IDialogParameters parameters, MulticastDelegate callback)
+    {
+        try
+        {
+            parameters = UriParsingHelper.GetSegmentParameters(name, parameters ?? new DialogParameters());
+
+            // This needs to be resolved when called as a Module could load any time
+            // and register new dialogs
+            var registry = _container.Resolve<IDialogViewRegistry>();
+            var view = registry.CreateView(_container, UriParsingHelper.GetSegmentName(name)) as View;
+
+            var currentPage = _pageAccessor.Page;
+            var dialogModal = _container.Resolve<IDialogContainer>();
+            var dialogAware = GetDialogController(view);
+
+            async Task DialogAware_RequestClose(IDialogParameters outParameters)
+            {
+                try
+                {
+                    var result = await CloseDialogAsync(outParameters ?? new DialogParameters(), currentPage, dialogModal);
+                    if (result.Exception is DialogException de && de.Message == DialogException.CanCloseIsFalse)
+                    {
+                        return;
+                    }
+
+                    await InvokeCallback(callback, result);
+                    GC.Collect();
+                }
+                catch (DialogException dex)
+                {
+                    var result = new DialogResult
+                    {
+                        Exception = dex,
+                        Parameters = parameters
+                    };
+
+                    if (dex.Message != DialogException.CanCloseIsFalse)
+                    {
+                        await InvokeError(callback, dex, parameters);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    await InvokeError(callback, ex, parameters);
+                }
+            }
+
+            dialogAware.RequestClose = new (DialogAware_RequestClose);
+
+            dialogAware.OnDialogOpened(parameters);
+
+            if (!parameters.TryGetValue<bool>(KnownDialogParameters.CloseOnBackgroundTapped, out var closeOnBackgroundTapped))
+            {
+                var dialogLayoutCloseOnBackgroundTapped = DialogLayout.GetCloseOnBackgroundTapped(view);
+                if (dialogLayoutCloseOnBackgroundTapped.HasValue)
+                {
+                    closeOnBackgroundTapped = dialogLayoutCloseOnBackgroundTapped.Value;
+                }
+            }
+
+            var dismissCommand = new DelegateCommand(() => dialogAware.RequestClose.Invoke(), dialogAware.CanCloseDialog);
+
+            PageNavigationService.NavigationSource = PageNavigationSource.DialogService;
+            dialogModal.ConfigureLayout(_pageAccessor.Page, view, closeOnBackgroundTapped, dismissCommand);
+            PageNavigationService.NavigationSource = PageNavigationSource.Device;
+
+            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(currentPage, aa => aa.IsActive = false);
+            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(view, aa => aa.IsActive = true);
+        }
+        catch (Exception ex)
+        {
+            _ = InvokeError(callback, ex);
+        }
+    }
+
+    private async Task InvokeError(MulticastDelegate callback, Exception exception, IDialogParameters parameters = null)
+    {
+        var result = new DialogResult 
+        {
+            Parameters = parameters,
+            Exception = exception 
+        };
+        await InvokeCallback(callback, result);
+    }
+
+    private async Task InvokeCallback(MulticastDelegate callback, IDialogResult result)
+    {
+        if (callback is null)
+            return;
+        else if (callback is Action<IDialogResult> actionCallback)
+            actionCallback(result);
+        else if (callback is Func<IDialogResult, Task> taskCallback)
+            await taskCallback(result);
+    }
+
+    private static async Task<IDialogResult> CloseDialogAsync(IDialogParameters parameters, Page currentPage, IDialogContainer dialogModal)
+    {
+        try
+        {
+            PageNavigationService.NavigationSource = PageNavigationSource.DialogService;
+
+            parameters ??= new DialogParameters();
+
+            var view = dialogModal.DialogView;
+            var dialogAware = GetDialogController(view);
+
+            if (!dialogAware.CanCloseDialog())
+            {
+                throw new DialogException(DialogException.CanCloseIsFalse);
+            }
+
+            PageNavigationService.NavigationSource = PageNavigationSource.DialogService;
+            await dialogModal.DoPop(currentPage);
+            PageNavigationService.NavigationSource = PageNavigationSource.Device;
+
+            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(view, aa => aa.IsActive = false);
+            MvvmHelpers.InvokeViewAndViewModelAction<IActiveAware>(currentPage, aa => aa.IsActive = true);
+            dialogAware.OnDialogClosed();
+
+            return new DialogResult
+            {
+                Parameters = parameters
+            };
+        }
+        catch (DialogException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            return new DialogResult
+            {
+                Exception = ex,
+                Parameters = parameters
+            };
+        }
+        finally
+        {
+            PageNavigationService.NavigationSource = PageNavigationSource.Device;
+        }
+    }
+
+    private static IDialogAware GetDialogController(View view)
+    {
+        if (view is IDialogAware viewAsDialogAware)
+        {
+            return viewAsDialogAware;
+        }
+        else if (view.BindingContext is null)
+        {
+            throw new DialogException(DialogException.NoViewModel);
+        }
+        else if (view.BindingContext is IDialogAware dialogAware)
+        {
+            return dialogAware;
+        }
+
+        throw new DialogException(DialogException.ImplementIDialogAware);
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/DialogViewRegistry.cs
+++ b/src/Prism.Maui/Services/Dialogs/DialogViewRegistry.cs
@@ -1,0 +1,17 @@
+﻿using Prism.Ioc;
+using Prism.Mvvm;
+using Prism.Common;
+
+namespace Prism.Services;
+
+public class DialogViewRegistry : ViewRegistryBase, IDialogViewRegistry
+{
+    public DialogViewRegistry(IEnumerable<ViewRegistration> registrations)
+        : base(ViewType.Dialog, registrations)
+    {
+    }
+
+    protected override void ConfigureView(BindableObject bindable, IContainerProvider container)
+    {
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/IDialogAware.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogAware.cs
@@ -1,0 +1,12 @@
+﻿namespace Prism.Services;
+
+public interface IDialogAware
+{
+    bool CanCloseDialog();
+
+    void OnDialogClosed();
+
+    void OnDialogOpened(IDialogParameters parameters);
+
+    DialogCloseEvent RequestClose { get; set; }
+}

--- a/src/Prism.Maui/Services/Dialogs/IDialogContainer.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogContainer.cs
@@ -1,0 +1,11 @@
+﻿using System.Windows.Input;
+
+namespace Prism.Services;
+
+public interface IDialogContainer
+{
+    View DialogView { get; }
+    ICommand Dismiss { get; }
+    Task ConfigureLayout(Page currentPage, View dialogView, bool hideOnBackgroundTapped, ICommand dismissCommand);
+    Task DoPop(Page currentPage);
+}

--- a/src/Prism.Maui/Services/Dialogs/IDialogParameters.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogParameters.cs
@@ -1,6 +1,6 @@
 ﻿using Prism.Common;
 
-namespace Prism.Services.Dialogs;
+namespace Prism.Services;
 
 /// <summary>
 /// Provides a way for the <see cref="IDialogService"/> to pass parameters when displaying a dialog.

--- a/src/Prism.Maui/Services/Dialogs/IDialogResult.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogResult.cs
@@ -1,4 +1,4 @@
-﻿namespace Prism.Services.Dialogs;
+﻿namespace Prism.Services;
 
 public interface IDialogResult
 {

--- a/src/Prism.Maui/Services/Dialogs/IDialogService.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogService.cs
@@ -22,24 +22,5 @@ public interface IDialogService
     /// _dialogService.ShowDialog("DemoDialog", parameters, <paramref name="callback"/>: null);
     /// </code>
     /// </example>
-    void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback);
-
-    /// <summary>
-    /// Displays a dialog.
-    /// </summary>
-    /// <param name="name">The unique name of the dialog to display. Must match an entry in the <see cref="Prism.Ioc.IContainerRegistry"/>.</param>
-    /// <param name="parameters">Parameters that the dialog can use for custom functionality.</param>
-    /// <param name="callback">The action to be invoked upon successful or failed completion of displaying the dialog.</param>
-    /// <example>
-    /// This example shows how to display a dialog with two parameters.
-    /// <code>
-    /// var parameters = new DialogParameters
-    /// {
-    ///     { "title", "Connection Lost!" },
-    ///     { "message", "We seem to have lost network connectivity" }
-    /// };
-    /// _dialogService.ShowDialog("DemoDialog", parameters, <paramref name="callback"/>: null);
-    /// </code>
-    /// </example>
-    void ShowDialog(string name, IDialogParameters parameters, Func<IDialogResult, Task> callback);
+    void ShowDialog(string name, IDialogParameters parameters, DialogCallback callback);
 }

--- a/src/Prism.Maui/Services/Dialogs/IDialogService.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogService.cs
@@ -1,4 +1,4 @@
-﻿namespace Prism.Services.Dialogs;
+﻿namespace Prism.Services;
 
 /// <summary>
 /// Defines a contract for displaying dialogs from ViewModels.
@@ -23,4 +23,23 @@ public interface IDialogService
     /// </code>
     /// </example>
     void ShowDialog(string name, IDialogParameters parameters, Action<IDialogResult> callback);
+
+    /// <summary>
+    /// Displays a dialog.
+    /// </summary>
+    /// <param name="name">The unique name of the dialog to display. Must match an entry in the <see cref="Prism.Ioc.IContainerRegistry"/>.</param>
+    /// <param name="parameters">Parameters that the dialog can use for custom functionality.</param>
+    /// <param name="callback">The action to be invoked upon successful or failed completion of displaying the dialog.</param>
+    /// <example>
+    /// This example shows how to display a dialog with two parameters.
+    /// <code>
+    /// var parameters = new DialogParameters
+    /// {
+    ///     { "title", "Connection Lost!" },
+    ///     { "message", "We seem to have lost network connectivity" }
+    /// };
+    /// _dialogService.ShowDialog("DemoDialog", parameters, <paramref name="callback"/>: null);
+    /// </code>
+    /// </example>
+    void ShowDialog(string name, IDialogParameters parameters, Func<IDialogResult, Task> callback);
 }

--- a/src/Prism.Maui/Services/Dialogs/IDialogServiceExtensions.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogServiceExtensions.cs
@@ -1,0 +1,20 @@
+﻿namespace Prism.Services;
+
+public static class IDialogServiceExtensions
+{
+    public static void ShowDialog(this IDialogService dialogService, string name, IDialogParameters parameters) =>
+        dialogService.ShowDialog(name, parameters, _ => Task.CompletedTask);
+
+    public static void ShowDialog(this IDialogService dialogService, string name) =>
+        dialogService.ShowDialog(name, new DialogParameters());
+
+    public static Task<IDialogResult> ShowDialogAsync(this IDialogService dialogService, string name) =>
+        dialogService.ShowDialogAsync(name, new DialogParameters());
+
+    public static Task<IDialogResult> ShowDialogAsync(this IDialogService dialogService, string name, IDialogParameters parameters)
+    {
+        var tcs = new TaskCompletionSource<IDialogResult>();
+        dialogService.ShowDialog(name, parameters, result => tcs.SetResult(result));
+        return tcs.Task;
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/IDialogServiceExtensions.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogServiceExtensions.cs
@@ -3,7 +3,7 @@
 public static class IDialogServiceExtensions
 {
     public static void ShowDialog(this IDialogService dialogService, string name, IDialogParameters parameters) =>
-        dialogService.ShowDialog(name, parameters, _ => Task.CompletedTask);
+        dialogService.ShowDialog(name, parameters, default);
 
     public static void ShowDialog(this IDialogService dialogService, string name) =>
         dialogService.ShowDialog(name, new DialogParameters());
@@ -11,10 +11,22 @@ public static class IDialogServiceExtensions
     public static Task<IDialogResult> ShowDialogAsync(this IDialogService dialogService, string name) =>
         dialogService.ShowDialogAsync(name, new DialogParameters());
 
+    public static void ShowDialog(this IDialogService dialogService, string name, Action callback) =>
+        dialogService.ShowDialog(name, null, callback);
+
+    public static void ShowDialog(this IDialogService dialogService, string name, Action<IDialogResult> callback) =>
+        dialogService.ShowDialog(name, null, callback);
+
+    public static void ShowDialog(this IDialogService dialogService, string name, IDialogParameters parameters, Action callback) =>
+        dialogService.ShowDialog(name, parameters, DialogCallback.OnClose(callback));
+
+    public static void ShowDialog(this IDialogService dialogService, string name, IDialogParameters parameters, Action<IDialogResult> callback) =>
+        dialogService.ShowDialog(name, parameters, DialogCallback.OnClose(callback));
+
     public static Task<IDialogResult> ShowDialogAsync(this IDialogService dialogService, string name, IDialogParameters parameters)
     {
         var tcs = new TaskCompletionSource<IDialogResult>();
-        dialogService.ShowDialog(name, parameters, result => tcs.SetResult(result));
+        dialogService.ShowDialog(name, parameters, result => tcs.TrySetResult(result));
         return tcs.Task;
     }
 }

--- a/src/Prism.Maui/Services/Dialogs/IDialogViewRegistry.cs
+++ b/src/Prism.Maui/Services/Dialogs/IDialogViewRegistry.cs
@@ -1,0 +1,7 @@
+﻿using Prism.Mvvm;
+
+namespace Prism.Services;
+
+public interface IDialogViewRegistry : IViewRegistry
+{
+}

--- a/src/Prism.Maui/Services/Dialogs/KnownDialogParameters.cs
+++ b/src/Prism.Maui/Services/Dialogs/KnownDialogParameters.cs
@@ -1,5 +1,5 @@
 ﻿
-namespace Prism.Services.Dialogs;
+namespace Prism.Services;
 
 public static class KnownDialogParameters
 {

--- a/src/Prism.Maui/Services/Dialogs/RelativeContentSizeConverter.cs
+++ b/src/Prism.Maui/Services/Dialogs/RelativeContentSizeConverter.cs
@@ -1,0 +1,38 @@
+﻿using System.Globalization;
+
+namespace Prism.Services;
+
+internal class RelativeContentSizeConverter : IValueConverter
+{
+    private double relativeSize;
+    public double RelativeSize
+    {
+        get => relativeSize;
+        set
+        {
+            if (value == 0)
+            {
+                relativeSize = 1;
+            }
+            else if (value > 1)
+            {
+                relativeSize = value / 100;
+            }
+            else
+            {
+                relativeSize = value;
+            }
+        }
+    }
+
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        var pageSize = double.Parse(value.ToString());
+        return RelativeSize * pageSize;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Prism.Maui/Services/Dialogs/Xaml/DialogLayout.cs
+++ b/src/Prism.Maui/Services/Dialogs/Xaml/DialogLayout.cs
@@ -1,0 +1,78 @@
+﻿namespace Prism.Services.Xaml;
+
+public static class DialogLayout
+{
+    /// <summary>
+    /// Gets the key for specifying or retrieving popup overlay style from Application Resources.
+    /// </summary>
+    public const string PopupOverlayStyle = "PrismDialogMaskStyle";
+
+    public static readonly BindableProperty RelativeWidthRequestProperty =
+        BindableProperty.CreateAttached("RelativeWidthRequest", typeof(double?), typeof(DialogLayout), null);
+
+    public static double? GetRelativeWidthRequest(BindableObject bindable) =>
+        (double?)bindable.GetValue(RelativeWidthRequestProperty);
+
+    public static void SetRelativeWidthRequest(BindableObject bindable, double? value) =>
+        bindable.SetValue(RelativeWidthRequestProperty, value);
+
+    public static readonly BindableProperty RelativeHeightRequestProperty =
+        BindableProperty.CreateAttached("RelativeHeightRequest", typeof(double?), typeof(DialogLayout), null);
+
+    public static double? GetRelativeHeightRequest(BindableObject bindable) =>
+        (double?)bindable.GetValue(RelativeHeightRequestProperty);
+
+    public static void SetRelativeHeightRequest(BindableObject bindable, double? value) =>
+        bindable.SetValue(RelativeHeightRequestProperty, value);
+
+    public static readonly BindableProperty LayoutBoundsProperty =
+        BindableProperty.CreateAttached("LayoutBounds", typeof(Rect), typeof(DialogLayout), new Rect(0.5, 0.5, -1, -1));
+
+    public static Rect GetLayoutBounds(BindableObject bindable) =>
+        (Rect)bindable.GetValue(LayoutBoundsProperty);
+
+    public static void SetLayoutBounds(BindableObject bindable, Rect value) =>
+        bindable.SetValue(LayoutBoundsProperty, value);
+
+    public static readonly BindableProperty MaskStyleProperty =
+        BindableProperty.CreateAttached("MaskStyle", typeof(Style), typeof(DialogLayout), null);
+
+    public static Style GetMaskStyle(BindableObject bindable) =>
+        (Style)bindable.GetValue(MaskStyleProperty);
+
+    public static void SetMaskStyle(BindableObject bindable, Style value) =>
+        bindable.SetValue(MaskStyleProperty, value);
+
+    public static readonly BindableProperty MaskProperty =
+        BindableProperty.CreateAttached("Mask", typeof(View), typeof(DialogLayout), null);
+
+    public static View GetMask(BindableObject bindable) =>
+        (View)bindable.GetValue(MaskProperty);
+
+    public static void SetMask(BindableObject bindable, View value) =>
+        bindable.SetValue(MaskProperty, value);
+
+    public static readonly BindableProperty UseMaskProperty =
+        BindableProperty.CreateAttached("UseMask", typeof(bool?), typeof(DialogLayout), null);
+
+    public static bool? GetUseMask(BindableObject bindable)
+    {
+        var value = bindable.GetValue(UseMaskProperty);
+        if (value is bool boolean)
+            return boolean;
+
+        return true;
+    }
+
+    public static void SetUseMask(BindableObject bindable, bool? value) =>
+        bindable.SetValue(UseMaskProperty, value);
+
+    public static readonly BindableProperty CloseOnBackgroundTappedProperty =
+        BindableProperty.CreateAttached("CloseOnBackgroundTapped", typeof(bool?), typeof(DialogLayout), null);
+
+    public static bool? GetCloseOnBackgroundTapped(BindableObject bindable) =>
+        (bool?)bindable.GetValue(CloseOnBackgroundTappedProperty);
+
+    public static void SetCloseOnBackgroundTapped(BindableObject bindable, bool? value) =>
+        bindable.SetValue(CloseOnBackgroundTappedProperty, value);
+}

--- a/src/Prism.Maui/Services/Dialogs/Xaml/ShowDialogExtension.cs
+++ b/src/Prism.Maui/Services/Dialogs/Xaml/ShowDialogExtension.cs
@@ -1,0 +1,56 @@
+﻿using System.Windows.Input;
+using Microsoft.Extensions.Logging;
+using Prism.Ioc;
+using Prism.Navigation.Xaml;
+using Prism.Xaml;
+
+namespace Prism.Services.Xaml;
+
+[ContentProperty(nameof(Name))]
+public class ShowDialogExtension : TargetAwareExtensionBase<ICommand>, ICommand
+{
+    public string Name { get; set; }
+
+    public bool IsExecuting { get; set; }
+
+    public event EventHandler CanExecuteChanged;
+
+    public bool CanExecute(object parameter) =>
+        !IsExecuting;
+
+    public void Execute(object parameter)
+    {
+        IsExecuting = true;
+        CanExecuteChanged(this, EventArgs.Empty);
+
+        try
+        {
+            var parameters = parameter.ToDialogParameters(TargetElement);
+            var dialogService = Page.GetContainerProvider().Resolve<IDialogService>();
+            dialogService.ShowDialog(Name, parameters, DialogClosedCallback);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning($"An unexpected error occurred while showing the Dialog '{Name}'.\n{ex}");
+        }
+    }
+
+    private void DialogClosedCallback(IDialogResult result)
+    {
+        OnDialogClosed(result);
+
+        IsExecuting = false;
+        CanExecuteChanged(this, EventArgs.Empty);
+    }
+
+    protected virtual void OnDialogClosed(IDialogResult result)
+    {
+        if (result.Exception != null)
+        {
+            Logger.LogWarning($"Dialog '{Name}' closed with an error:\n{result.Exception}");
+        }
+    }
+
+    protected override ICommand ProvideValue(IServiceProvider serviceProvider) =>
+        this;
+}

--- a/src/Prism.Maui/Services/Dialogs/Xaml/ShowDialogExtension.cs
+++ b/src/Prism.Maui/Services/Dialogs/Xaml/ShowDialogExtension.cs
@@ -9,9 +9,23 @@ namespace Prism.Services.Xaml;
 [ContentProperty(nameof(Name))]
 public class ShowDialogExtension : TargetAwareExtensionBase<ICommand>, ICommand
 {
-    public string Name { get; set; }
+    public static readonly BindableProperty NameProperty =
+        BindableProperty.Create(nameof(Name), typeof(string), typeof(ShowDialogExtension), null);
 
-    public bool IsExecuting { get; set; }
+    public static readonly BindableProperty IsExecutingProperty =
+        BindableProperty.Create(nameof(IsExecuting), typeof(bool), typeof(ShowDialogExtension), false);
+
+    public string Name
+    {
+        get => (string)GetValue(NameProperty);
+        set => SetValue(NameProperty, value);
+    }
+
+    public bool IsExecuting
+    {
+        get => (bool)GetValue(IsExecutingProperty);
+        set => SetValue(IsExecutingProperty, value);
+    }
 
     public event EventHandler CanExecuteChanged;
 

--- a/src/Prism.Maui/Xaml/ParameterExtensions.cs
+++ b/src/Prism.Maui/Xaml/ParameterExtensions.cs
@@ -1,5 +1,5 @@
 ﻿using Prism.Navigation;
-using Prism.Services.Dialogs;
+using Prism.Services;
 
 namespace Prism.Xaml;
 


### PR DESCRIPTION
# Description

Implements the IDialogService from Prism.Forms. This makes a few minor tweaks to the API...

- closes #21

## DialogCallback

This introduces a new `DialogCallback` struct which provides some flexibility in providing delegates for handling the DialogService callback:

```cs
DialogCallback.OnClose(() => { /* Do Something */ });

DialogCallback.OnClose(result => { /* Do Something with the Result */ });

DialogCallback.OnError(exception => { /* Handle an exception from the Dialog Service */});
```

Additionally the DialogCallback allows you to easily provide an async delegate like:

```cs
DialogCallback.OnCloseAsync(() => Task.CompletedTask);

DialogCallback.OnCloseAsync(result => Task.CompletedTask);

DialogCallback.OnErrorAsync(exception => Task.CompletedTask);
```

## Extensions

Extensions are built in when using `Action` or `Action<IDialogResult`. This means that you can simply provide your delegate when calling ShowDialog

```cs
dialogService.ShowDialog("MyDialog", parameters, () => Console.WriteLine("Dialog Closed"));

dialogService.ShowDialog("MyDialog", parameters, result => Console.WriteLine("Dialog Closed"));
```

To use any other delegate for your DialogCallback you will need to initialize the DialogCallback using one of the factory methods noted above.

## IDialogContainer

This further refactors some of the design of the service from Prism.Forms and formalizes the use of the IDialogContainer. All styling, push/pop management occurs within the IDialogContainer rather than the DialogService itself. You can easily modify default styling behavior or even swap to use Popups instead of a Modal Page by simply implementing the IDialogContainer and registering it with the container using the included registration extension.