### PR TITLE
Go Back To View

### DIFF
--- a/src/Prism.Maui/Mvvm/ViewModelLocator.cs
+++ b/src/Prism.Maui/Mvvm/ViewModelLocator.cs
@@ -21,6 +21,12 @@ public static class ViewModelLocator
     internal static readonly BindableProperty NavigationNameProperty =
         BindableProperty.CreateAttached("NavigationName", typeof(string), typeof(ViewModelLocator), null);
 
+    internal static string GetNavigationName(BindableObject bindable) =>
+        (string)bindable.GetValue(NavigationNameProperty);
+
+    internal static void SetNavigationName(BindableObject bindable, string name) =>
+        bindable.SetValue(NavigationNameProperty, name);
+
     /// <summary>
     /// Gets the AutowireViewModel property value.
     /// </summary>

--- a/src/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
@@ -11,6 +11,7 @@ public interface INavigationBuilder
     INavigationBuilder UseAbsoluteNavigation(bool absolute);
     INavigationBuilder UseRelativeNavigation();
 
+    Task<INavigationResult> GoBackTo<TViewModel>(INavigationParameters parameters);
     Task<INavigationResult> NavigateAsync();
     Task NavigateAsync(Action<Exception> onError);
     Task NavigateAsync(Action onSuccess, Action<Exception> onError);

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
@@ -45,6 +45,12 @@ internal class NavigationBuilder : INavigationBuilder, IRegistryAware
         return this;
     }
 
+    public async Task<INavigationResult> GoBackTo<TViewModel>(INavigationParameters parameters)
+    {
+        var name = NavigationBuilderExtensions.GetNavigationKey<TViewModel>(this);
+        return await _navigationService.GoBackToAsync(name, parameters);
+    }
+
     public Task<INavigationResult> NavigateAsync()
     {
         return _navigationService.NavigateAsync(BuildUri(), _navigationParameters);

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilderExtensions.cs
@@ -13,6 +13,9 @@ public static class NavigationBuilderExtensions
     public static INavigationBuilder CreateBuilder(this INavigationService navigationService) =>
            new NavigationBuilder(navigationService);
 
+    public static Task<INavigationResult> GoBackTo<TViewModel>(this INavigationBuilder builder) =>
+        builder.GoBackTo<TViewModel>(null);
+
     internal static string GetNavigationKey<TViewModel>(object builder)
     {
         var vmType = typeof(TViewModel);

--- a/src/Prism.Maui/Navigation/INavigationService.cs
+++ b/src/Prism.Maui/Navigation/INavigationService.cs
@@ -8,6 +8,14 @@ public interface INavigationService
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
+    /// <param name="name">The name of the View to navigate back to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    Task<INavigationResult> GoBackToAsync(string name, INavigationParameters parameters);
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
     /// <param name="parameters">The navigation parameters</param>
     /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
     Task<INavigationResult> GoBackAsync(INavigationParameters parameters);

--- a/src/Prism.Maui/Navigation/INavigationServiceExtensions.cs
+++ b/src/Prism.Maui/Navigation/INavigationServiceExtensions.cs
@@ -10,7 +10,15 @@ public static class INavigationServiceExtensions
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
-    /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
+    /// <param name="name">The name of the View to navigate back to</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    public static Task<INavigationResult> GoBackToAsync(this INavigationService navigationService, string name) =>
+        navigationService.GoBackToAsync(name, null);
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
     public static Task<INavigationResult> GoBackAsync(this INavigationService navigationService) =>
         navigationService.GoBackAsync(null);
 

--- a/src/Prism.Maui/Navigation/PageNavigationService.cs
+++ b/src/Prism.Maui/Navigation/PageNavigationService.cs
@@ -63,6 +63,67 @@ public class PageNavigationService : INavigationService, IRegistryAware
     /// <summary>
     /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
     /// </summary>
+    /// <param name="name">The name of the View to navigate back to</param>
+    /// <param name="parameters">The navigation parameters</param>
+    /// <returns><see cref="INavigationResult"/> indicating whether the request was successful or if there was an encountered <see cref="Exception"/>.</returns>
+    public virtual async Task<INavigationResult> GoBackToAsync(string name, INavigationParameters parameters)
+    {
+        await _semaphore.WaitAsync();
+        Page page = null;
+        try
+        {
+            parameters ??= new NavigationParameters();
+            NavigationSource = PageNavigationSource.NavigationService;
+            if (string.IsNullOrEmpty(name))
+                throw new ArgumentNullException("No Navigation Key was specified to Navigate Back To");
+            else if (!Registry.IsRegistered(name))
+                throw new NavigationException(NavigationException.NoPageIsRegistered, name);
+
+            page = GetCurrentPage();
+            parameters.GetNavigationParametersInternal().Add(KnownInternalParameters.NavigationMode, NavigationMode.Back);
+
+            while (page is not null && ViewModelLocator.GetNavigationName(page) != name)
+            {
+                if (IsRoot(GetPageFromWindow(), page))
+                    throw new NavigationException(NavigationException.CannotPopApplicationMainPage, page);
+
+                var canNavigate = await MvvmHelpers.CanNavigateAsync(page, parameters);
+                if (!canNavigate)
+                {
+                    throw new NavigationException(NavigationException.IConfirmNavigationReturnedFalse, page);
+                }
+
+                bool useModalForDoPop = UseModalGoBack(page, parameters);
+                Page previousPage = MvvmHelpers.GetOnNavigatedToTarget(page, Window?.Page, useModalForDoPop);
+
+                bool animated = parameters.ContainsKey(KnownNavigationParameters.Animated) ? parameters.GetValue<bool>(KnownNavigationParameters.Animated) : true;
+                var poppedPage = await DoPop(page.Navigation, useModalForDoPop, animated);
+                if (poppedPage != null)
+                {
+                    MvvmHelpers.OnNavigatedFrom(page, parameters);
+                    MvvmHelpers.OnNavigatedTo(previousPage, parameters);
+                    MvvmHelpers.DestroyPage(poppedPage);
+                }
+
+                page = previousPage;
+            }
+
+            return Notify(NavigationRequestType.GoBack, parameters);
+        }
+        catch (Exception ex)
+        {
+            return Notify(NavigationRequestType.GoBack, parameters, ex);
+        }
+        finally
+        {
+            NavigationSource = PageNavigationSource.Device;
+            _semaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// Navigates to the most recent entry in the back navigation history by popping the calling Page off the navigation stack.
+    /// </summary>
     /// <param name="parameters">The navigation parameters</param>
     /// <returns>If <c>true</c> a go back operation was successful. If <c>false</c> the go back operation failed.</returns>
     public virtual async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
@@ -71,8 +132,7 @@ public class PageNavigationService : INavigationService, IRegistryAware
         Page page = null;
         try
         {
-            if (parameters is null)
-                parameters = new NavigationParameters();
+            parameters ??= new NavigationParameters();
 
             NavigationSource = PageNavigationSource.NavigationService;
 

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/Navigation/NavigationTests.cs
@@ -151,6 +151,53 @@ public class NavigationTests : TestBase
         Assert.Equal(2, rootPage.Navigation.ModalStack.Count);
     }
 
+    [Fact]
+    public async Task GoBackTo_Name_PopsToSpecifiedView()
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
+            .Build();
+        var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
+        var window = app!.Windows.First();
+
+        Assert.IsAssignableFrom<NavigationPage>(window.Page);
+        var navigationPage = (NavigationPage)window.Page;
+
+        Assert.IsType<MockViewA>(navigationPage.RootPage);
+        Assert.IsType<MockViewE>(navigationPage.CurrentPage);
+
+        var result = await navigationPage.CurrentPage.GetContainerProvider()
+            .Resolve<INavigationService>()
+            .GoBackToAsync("MockViewC");
+
+        Assert.True(result.Success);
+
+        Assert.IsType<MockViewC>(navigationPage.CurrentPage);
+    }
+
+    [Fact]
+    public async Task GoBackTo_ViewModel_PopsToSpecifiedView()
+    {
+        var mauiApp = CreateBuilder(prism => prism.OnAppStart("NavigationPage/MockViewA/MockViewB/MockViewC/MockViewD/MockViewE"))
+            .Build();
+        var app = mauiApp.Services.GetRequiredService<IApplication>() as Application;
+        var window = app!.Windows.First();
+
+        Assert.IsAssignableFrom<NavigationPage>(window.Page);
+        var navigationPage = (NavigationPage)window.Page;
+
+        Assert.IsType<MockViewA>(navigationPage.RootPage);
+        Assert.IsType<MockViewE>(navigationPage.CurrentPage);
+
+        var result = await navigationPage.CurrentPage.GetContainerProvider()
+            .Resolve<INavigationService>()
+            .CreateBuilder()
+            .GoBackTo<MockViewCViewModel>();
+
+        Assert.True(result.Success);
+
+        Assert.IsType<MockViewC>(navigationPage.CurrentPage);
+    }
+
     private void TestPage(Page page)
     {
         Assert.NotNull(page.BindingContext);

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/TestBase.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/TestBase.cs
@@ -28,7 +28,9 @@ public abstract class TestBase
                     container.RegisterForNavigation<MockHome, MockHomeViewModel>()
                         .RegisterForNavigation<MockViewA, MockViewAViewModel>()
                         .RegisterForNavigation<MockViewB, MockViewBViewModel>()
-                        .RegisterForNavigation<MockViewC, MockViewCViewModel>();
+                        .RegisterForNavigation<MockViewC, MockViewCViewModel>()
+                        .RegisterForNavigation<MockViewD, MockViewDViewModel>()
+                        .RegisterForNavigation<MockViewE, MockViewEViewModel>();
                 })
                 .ConfigureLogging(builder =>
                     builder.AddProvider(new XUnitLoggerProvider(_testOutputHelper)))

--- a/tests/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewDViewModel.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewDViewModel.cs
@@ -1,0 +1,10 @@
+﻿using Prism.Common;
+
+namespace Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
+
+public class MockViewDViewModel : MockViewModelBase
+{
+    public MockViewDViewModel(IPageAccessor pageAccessor, INavigationService navigationService) : base(pageAccessor, navigationService)
+    {
+    }
+}

--- a/tests/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewEViewModel.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Mocks/ViewModels/MockViewEViewModel.cs
@@ -1,0 +1,10 @@
+﻿using Prism.Common;
+
+namespace Prism.DryIoc.Maui.Tests.Mocks.ViewModels;
+
+public class MockViewEViewModel : MockViewModelBase
+{
+    public MockViewEViewModel(IPageAccessor pageAccessor, INavigationService navigationService) : base(pageAccessor, navigationService)
+    {
+    }
+}

--- a/tests/Prism.DryIoc.Maui.Tests/Mocks/Views/MockViewD.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Mocks/Views/MockViewD.cs
@@ -1,0 +1,3 @@
+﻿namespace Prism.DryIoc.Maui.Tests.Mocks.Views;
+
+public class MockViewD : ContentPage { }

--- a/tests/Prism.DryIoc.Maui.Tests/Mocks/Views/MockViewE.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Mocks/Views/MockViewE.cs
@@ -1,0 +1,3 @@
+﻿namespace Prism.DryIoc.Maui.Tests.Mocks.Views;
+
+public class MockViewE : ContentPage { }


### PR DESCRIPTION
# Description

Implements GoBackTo Page in the NavigationService. This also updates the NavigationBuilder with an API that supports ViewModel first Navigation to GoBack to the specified View.

```cs
navigationService.GoBackToAsync("MyView");

navigationService.CreateBuilder()
    .GoBackToAsync<MyViewModel>();
```

- closes #70 