### PR TITLE
Add AddTabbedSegment with segment name

### DIFF
--- a/src/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/INavigationBuilder.cs
@@ -5,6 +5,7 @@ public interface INavigationBuilder
     Uri Uri { get; }
     INavigationBuilder AddSegment(string segmentName, Action<ISegmentBuilder> configureSegment);
     INavigationBuilder AddTabbedSegment(Action<ITabbedSegmentBuilder> configuration);
+    INavigationBuilder AddTabbedSegment(string segmentName, Action<ITabbedSegmentBuilder> configureSegment);
     INavigationBuilder WithParameters(INavigationParameters parameters);
     INavigationBuilder AddParameter(string key, object value);
 

--- a/src/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/NavigationBuilder.cs
@@ -39,6 +39,14 @@ internal class NavigationBuilder : INavigationBuilder, IRegistryAware
         return this;
     }
 
+    public INavigationBuilder AddTabbedSegment(string segmentName, Action<ITabbedSegmentBuilder> configureSegment)
+    {
+        var builder = new TabbedSegmentBuilder(this, segmentName);
+        configureSegment?.Invoke(builder);
+        _uriSegments.Add(builder);
+        return this;
+    }
+
     public INavigationBuilder AddParameter(string key, object value)
     {
         _navigationParameters.Add(key, value);

--- a/src/Prism.Maui/Navigation/Builder/TabbedSegmentBuilder.cs
+++ b/src/Prism.Maui/Navigation/Builder/TabbedSegmentBuilder.cs
@@ -24,6 +24,21 @@ internal class TabbedSegmentBuilder : ITabbedSegmentBuilder, IConfigurableSegmen
         SegmentName = registration.Name;
     }
 
+    public TabbedSegmentBuilder(INavigationBuilder builder, string segmentName)
+    {
+        _builder = builder;
+        _parameters = new NavigationParameters();
+
+        if (builder is not IRegistryAware registryAware)
+            throw new Exception("The builder does not implement IRegistryAware");
+
+        var registration = registryAware.Registry.ViewsOfType(typeof(TabbedPage)).FirstOrDefault(x => x.Name == segmentName);
+        if (registration == null)
+            throw new NavigationException(NavigationException.NoPageIsRegistered, nameof(TabbedPage));
+
+        SegmentName = registration.Name;
+    }
+
     IViewRegistry IRegistryAware.Registry => ((IRegistryAware)_builder).Registry;
 
     public string SegmentName { get; set; }


### PR DESCRIPTION
A Builder method to generate TabbedPage subclasses was missing, so I added it.
I often use a modified version of native's Tab control, so it would be nice to be able to specify something other than the standard TabbedPage.