### PR TITLE
drop App generic for UsePrism method

### DIFF
--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -11,7 +11,8 @@ public static class MauiProgram
     public static MauiApp CreateMauiApp()
     {
         return MauiApp.CreateBuilder()
-            .UsePrismApp<App>(prism => 
+            .UseMauiApp<App>()
+            .UsePrism(prism => 
                 prism.ConfigureModuleCatalog(moduleCatalog =>
                 {
                     moduleCatalog.AddModule<MauiAppModule>();

--- a/src/Prism.DryIoc.Maui/PrismAppExtensions.cs
+++ b/src/Prism.DryIoc.Maui/PrismAppExtensions.cs
@@ -9,18 +9,16 @@ namespace Microsoft.Maui;
 /// </summary>
 public static class PrismAppExtensions
 {
-    public static MauiAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Action<PrismAppBuilder> configurePrism)
-        where TApp : Application
+    public static MauiAppBuilder UsePrism(this MauiAppBuilder builder, Action<PrismAppBuilder> configurePrism)
     {
-        return builder.UsePrismApp<TApp>(new DryIocContainerExtension(), configurePrism);
+        return builder.UsePrism(new DryIocContainerExtension(), configurePrism);
     }
 
-    public static MauiAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, Rules rules, Action<PrismAppBuilder> configurePrism)
-        where TApp : Application
+    public static MauiAppBuilder UsePrism(this MauiAppBuilder builder, Rules rules, Action<PrismAppBuilder> configurePrism)
     {
         rules = rules.WithTrackingDisposableTransients()
             .With(Made.Of(FactoryMethod.ConstructorWithResolvableArguments))
             .WithFactorySelector(Rules.SelectLastRegisteredFactory());
-        return builder.UsePrismApp<TApp>(new DryIocContainerExtension(rules), configurePrism);
+        return builder.UsePrism(new DryIocContainerExtension(rules), configurePrism);
     }
 }

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -16,17 +16,7 @@ using TabbedPage = Microsoft.Maui.Controls.TabbedPage;
 
 namespace Prism;
 
-public sealed class PrismAppBuilder<TApp> : PrismAppBuilder
-    where TApp : Application
-{
-    internal PrismAppBuilder(IContainerExtension containerExtension, MauiAppBuilder builder)
-        : base(containerExtension, builder)
-    {
-        builder.UseMauiApp<TApp>();
-    }
-}
-
-public abstract class PrismAppBuilder
+public sealed class PrismAppBuilder
 {
     private List<Action<IContainerRegistry>> _registrations { get; }
     private List<Action<IContainerProvider>> _initializations { get; }

--- a/src/Prism.Maui/PrismAppBuilderExtensions.cs
+++ b/src/Prism.Maui/PrismAppBuilderExtensions.cs
@@ -9,10 +9,9 @@ public static class PrismAppBuilderExtensions
 {
     private static bool s_didRegisterModules = false;
 
-    public static MauiAppBuilder UsePrismApp<TApp>(this MauiAppBuilder builder, IContainerExtension containerExtension, Action<PrismAppBuilder> configurePrism)
-        where TApp : Application
+    public static MauiAppBuilder UsePrism(this MauiAppBuilder builder, IContainerExtension containerExtension, Action<PrismAppBuilder> configurePrism)
     {
-        var prismBuilder = new PrismAppBuilder<TApp>(containerExtension, builder);
+        var prismBuilder = new PrismAppBuilder(containerExtension, builder);
         configurePrism(prismBuilder);
         return builder;
     }

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/Regions/RegionFixture.cs
@@ -10,7 +10,8 @@ public class RegionFixture
     public void ContentRegion_CreatedBy_RequestNavigate()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
@@ -36,7 +37,8 @@ public class RegionFixture
     public void FrameRegion_CreatedBy_RegisterViewWithRegion()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
@@ -67,7 +69,8 @@ public class RegionFixture
     public void RegionsShareContainer_WithPage()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
@@ -104,7 +107,8 @@ public class RegionFixture
     {
         // This validates that the NavigationService is using the correct Page to navigate from
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
@@ -128,7 +132,8 @@ public class RegionFixture
     public void RegionManager_HasTwoRegions()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism => 
+            .UseMauiApp<Application>()
+            .UsePrism(prism => 
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
@@ -144,7 +149,8 @@ public class RegionFixture
     public void PageHas_2_ChildViews()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockContentRegionPage, MockContentRegionPageViewModel>();
@@ -177,7 +183,8 @@ public class RegionFixture
     public void RegionWithDefaultView_IsAutoPopulated()
     {
         var mauiApp = MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
                 prism.RegisterTypes(container =>
                 {
                     container.RegisterForNavigation<MockPageWithRegionAndDefaultView>("MainPage");

--- a/tests/Prism.DryIoc.Maui.Tests/Fixtures/TestBase.cs
+++ b/tests/Prism.DryIoc.Maui.Tests/Fixtures/TestBase.cs
@@ -21,7 +21,8 @@ public abstract class TestBase
     protected MauiAppBuilder CreateBuilder(Action<PrismAppBuilder> configurePrism)
     {
         return MauiApp.CreateBuilder()
-            .UsePrismApp<Application>(prism =>
+            .UseMauiApp<Application>()
+            .UsePrism(prism =>
             {
                 prism.RegisterTypes(container =>
                 {


### PR DESCRIPTION
# Description

When Prism for .NET MAUI  began we anticipated requiring at least some code in the Application class and continuing to have a PrismApplication like we do with Prism for WPF, Uno, & Xamarin.Forms. As time has gone on and the .NET MAUI API has taken shape, and as Prism for .NET MAUI has grown to work with their updated API, there is no longer a need for a PrismApplication base class. As a result we really do not need to provide this as part of the bootstrapping for Prism.

## BREAKING CHANGE

```cs
// Old Code
var builder = MauiApp.CreateBuilder();
builder.UsePrismApp<App>(prism => {
    // configure Prism
});
```

This will now change to:
```cs
var builder = MauiApp.CreateBuilder();
builder.UseMauiApp<App>()
    .UsePrism(prism => {
        // Configure Prism
    });
```