### PR TITLE
Correct OnBackPressed return value

### DIFF
--- a/src/Prism.Maui/Common/MvvmHelpers.cs
+++ b/src/Prism.Maui/Common/MvvmHelpers.cs
@@ -272,10 +272,10 @@ public static class MvvmHelpers
         return GetOnNavigatedToTargetFromChild(page);
     };
 
-    public static async Task HandleNavigationPageGoBack(NavigationPage navigationPage)
+    public static async Task<INavigationResult> HandleNavigationPageGoBack(NavigationPage navigationPage)
     {
         var navigationService = Navigation.Xaml.Navigation.GetNavigationService(navigationPage.CurrentPage);
-        await navigationService.GoBackAsync();
+        return await navigationService.GoBackAsync();
     }
 
     public static void HandleSystemGoBack(IView previousPage, IView currentPage)

--- a/src/Prism.Maui/Controls/PrismNavigationPage.cs
+++ b/src/Prism.Maui/Controls/PrismNavigationPage.cs
@@ -25,6 +25,20 @@ public class PrismNavigationPage : NavigationPage
 
     private async void HandleBackButtonPressed(object sender, EventArgs args)
     {
-        await MvvmHelpers.HandleNavigationPageGoBack(this);
+        bool success;
+        try
+        {
+            var result = await MvvmHelpers.HandleNavigationPageGoBack(this).ConfigureAwait(false);
+            success = result.Success;
+        }
+        catch
+        {
+            success = false;
+        }
+
+        if (!success)
+        {
+            Application.Current.Quit();
+        }
     }
 }

--- a/src/Prism.Maui/Controls/PrismNavigationPage.cs
+++ b/src/Prism.Maui/Controls/PrismNavigationPage.cs
@@ -1,4 +1,5 @@
 ﻿using Prism.Common;
+using Prism.Navigation;
 
 namespace Prism.Controls;
 
@@ -25,18 +26,18 @@ public class PrismNavigationPage : NavigationPage
 
     private async void HandleBackButtonPressed(object sender, EventArgs args)
     {
-        bool success;
+        bool backingOut = false;
+
         try
         {
             var result = await MvvmHelpers.HandleNavigationPageGoBack(this).ConfigureAwait(false);
-            success = result.Success;
         }
-        catch
+        catch (NavigationException ex)
         {
-            success = false;
+            backingOut = ex.Message == NavigationException.CannotPopApplicationMainPage;
         }
 
-        if (!success)
+        if (backingOut)
         {
             Application.Current.Quit();
         }

--- a/src/Prism.Maui/Controls/PrismNavigationPage.cs
+++ b/src/Prism.Maui/Controls/PrismNavigationPage.cs
@@ -19,7 +19,7 @@ public class PrismNavigationPage : NavigationPage
 
     protected override bool OnBackButtonPressed()
     {
-        //BackButtonPressed.Invoke(this, EventArgs.Empty);
+        BackButtonPressed.Invoke(this, EventArgs.Empty);
         return false;
     }
 

--- a/src/Prism.Maui/Controls/PrismNavigationPage.cs
+++ b/src/Prism.Maui/Controls/PrismNavigationPage.cs
@@ -19,7 +19,7 @@ public class PrismNavigationPage : NavigationPage
 
     protected override bool OnBackButtonPressed()
     {
-        BackButtonPressed.Invoke(this, EventArgs.Empty);
+        //BackButtonPressed.Invoke(this, EventArgs.Empty);
         return false;
     }
 

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -45,12 +45,12 @@ public sealed class PrismAppBuilder
                 {
                     var root = ContainerLocator.Container;
                     if (root is null)
-                        return true;
+                        return false;
 
                     var app = root.Resolve<IApplication>();
                     var windows = app.Windows.OfType<PrismWindow>();
                     if (!windows.Any(x => x.IsActive))
-                        return true;
+                        return false;
 
                     var window = windows.First(x => x.IsActive);
                     var currentPage = window.CurrentPage;
@@ -66,7 +66,7 @@ public sealed class PrismAppBuilder
                         navigation.GoBackAsync();
                     }
 
-                    return false;
+                    return true;
                 });
             });
 #endif

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -60,15 +60,6 @@ public sealed class PrismAppBuilder
                         if (dialogContainer.Dismiss.CanExecute(null))
                             dialogContainer.Dismiss.Execute(null);
                     }
-                    else
-                    {
-                        var navigation = container.Resolve<INavigationService>();
-
-                        if (IsRoot(GetPageFromWindow(currentPage), currentPage))
-                            return false;
-
-                        navigation.GoBackAsync();
-                    }
 
                     return true;
                 });
@@ -86,40 +77,6 @@ public sealed class PrismAppBuilder
     }
 
     public MauiAppBuilder MauiBuilder { get; }
-
-    private static bool IsRoot(Page mainPage, Page currentPage)
-    {
-        if (mainPage == currentPage)
-            return true;
-
-        return mainPage switch
-        {
-            FlyoutPage fp => IsRoot(fp.Detail, currentPage),
-            TabbedPage tp => IsRoot(tp.CurrentPage, currentPage),
-            NavigationPage np => IsRoot(np.RootPage, currentPage),
-            _ => false
-        };
-    }
-
-    private static Page GetPageFromWindow(Page page)
-    {
-        try
-        {
-            return page?.GetParentWindow()?.Page;
-        }
-#if DEBUG
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine(ex);
-            return null;
-        }
-#else
-        catch
-        {
-            return null;
-        }
-#endif
-    }
 
     private void ConfigureViewModelLocator()
     {

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -63,6 +63,10 @@ public sealed class PrismAppBuilder
                     else
                     {
                         var navigation = container.Resolve<INavigationService>();
+
+                        if (IsRoot(GetPageFromWindow(currentPage), currentPage))
+                            return false;
+
                         navigation.GoBackAsync();
                     }
 
@@ -82,6 +86,40 @@ public sealed class PrismAppBuilder
     }
 
     public MauiAppBuilder MauiBuilder { get; }
+
+    private static bool IsRoot(Page mainPage, Page currentPage)
+    {
+        if (mainPage == currentPage)
+            return true;
+
+        return mainPage switch
+        {
+            FlyoutPage fp => IsRoot(fp.Detail, currentPage),
+            TabbedPage tp => IsRoot(tp.CurrentPage, currentPage),
+            NavigationPage np => IsRoot(np.RootPage, currentPage),
+            _ => false
+        };
+    }
+
+    private static Page GetPageFromWindow(Page page)
+    {
+        try
+        {
+            return page?.GetParentWindow()?.Page;
+        }
+#if DEBUG
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(ex);
+            return null;
+        }
+#else
+        catch
+        {
+            return null;
+        }
+#endif
+    }
 
     private void ConfigureViewModelLocator()
     {


### PR DESCRIPTION
Seems the MAUI docs aren't abundantly clear here, but comparing with Xamarin's [Page.OnBackButtonPressed Method](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.page.onbackbuttonpressed?view=xamarin-forms) -
> Application developers can override this method to provide behavior when the back button is pressed.
> ...
> Returns
> [Boolean](https://docs.microsoft.com/en-us/dotnet/api/system.boolean)
> Whether or not the back navigation was handled by the override.

So it looks like what was actually intended in the `PrismAppBuilder`'s handling of the back button is the reverse of the current implementation.  Current behavior is when I am in a page on a `NavigationPage` stack and hit back, Android backs out of the entire app.  Tested this fix in a workaround reconfiguration of `OnBackPressed` and pressing back behaves as expected.