### PR TITLE
General fixes

### DIFF
--- a/sample/PrismMauiDemo/MauiProgram.cs
+++ b/sample/PrismMauiDemo/MauiProgram.cs
@@ -20,7 +20,6 @@ public static class MauiProgram
                 })
                 .RegisterTypes(containerRegistry =>
                 {
-                    containerRegistry.RegisterGlobalNavigationObserver();
                     containerRegistry.RegisterForNavigation<MainPage>();
                     containerRegistry.RegisterForNavigation<RootPage>();
                     containerRegistry.RegisterForNavigation<SamplePage>();

--- a/sample/PrismMauiDemo/Platforms/Android/AndroidManifest.xml
+++ b/sample/PrismMauiDemo/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-  <uses-sdk android:minSdkVersion="21" android:targetSdkVersion="31" />
   <application android:allowBackup="true" android:icon="@mipmap/appicon" android:roundIcon="@mipmap/appicon_round" android:supportsRtl="true"></application>
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 </manifest>

--- a/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
+++ b/src/Prism.Maui.Rx/NavigationObserverRegistrationExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using Prism.Ioc;
+﻿using Prism.Ioc;
 
 namespace Prism.Navigation;
 
@@ -7,39 +6,27 @@ public static class NavigationObserverRegistrationExtensions
 {
     private static bool s_IsRegistered;
 
-    public static IContainerRegistry RegisterGlobalNavigationObserver(this IContainerRegistry container)
+    private static PrismAppBuilder RegisterGlobalNavigationObserver(this PrismAppBuilder builder)
     {
         if (s_IsRegistered)
-            return container;
+            return builder;
 
         s_IsRegistered = true;
-        return container.RegisterSingleton<IGlobalNavigationObserver, GlobalNavigationObserver>();
-    }
-
-    public static IServiceCollection RegisterGlobalNavigationObserver(this IServiceCollection services)
-    {
-        if (s_IsRegistered)
-            return services;
-
-        s_IsRegistered = true;
-        return services.AddSingleton<IGlobalNavigationObserver, GlobalNavigationObserver>();
+        return builder.RegisterTypes(c => 
+            c.RegisterSingleton<IGlobalNavigationObserver, GlobalNavigationObserver>());
     }
 
     public static PrismAppBuilder AddGlobalNavigationObserver(this PrismAppBuilder builder, Action<IObservable<NavigationRequestContext>> addObservable) =>
-        builder.OnInitialized(c =>
+        builder.RegisterGlobalNavigationObserver()
+        .OnInitialized(c =>
         {
-            if (!s_IsRegistered)
-                throw new Exception("IGlobalNavigationObserver has not been registered. Be sure to call 'container.RegisterGlobalNavigationObserver()'.");
-
             addObservable(c.Resolve<IGlobalNavigationObserver>().NavigationRequest);
         });
 
     public static PrismAppBuilder AddGlobalNavigationObserver(this PrismAppBuilder builder, Action<IContainerProvider, IObservable<NavigationRequestContext>> addObservable) =>
-        builder.OnInitialized(c =>
+        builder.RegisterGlobalNavigationObserver()
+        .OnInitialized(c =>
         {
-            if (!s_IsRegistered)
-                throw new Exception("IGlobalNavigationObserver has not been registered. Be sure to call 'container.RegisterGlobalNavigationObserver()'.");
-
             addObservable(c, c.Resolve<IGlobalNavigationObserver>().NavigationRequest);
         });
 }

--- a/src/Prism.Maui/PrismAppBuilder.cs
+++ b/src/Prism.Maui/PrismAppBuilder.cs
@@ -125,8 +125,13 @@ public sealed class PrismAppBuilder
         return this;
     }
 
+    private bool _initialized;
     internal void OnInitialized()
     {
+        if (_initialized)
+            return;
+
+        _initialized = true;
         _initializations.ForEach(action => action(_container));
 
         if (_container.IsRegistered<IModuleCatalog>() && _container.Resolve<IModuleCatalog>().Modules.Any())
@@ -160,6 +165,9 @@ public sealed class PrismAppBuilder
     {
         if (_onAppStarted is null)
             throw new ArgumentException("You must call OnAppStart on the PrismAppBuilder.");
+
+        // Ensure that this is executed before we navigate.
+        OnInitialized();
         var onStart = _onAppStarted(_container, _container.Resolve<INavigationService>());
         onStart.Wait();
     }


### PR DESCRIPTION
# Description

- Fixes issue where Maui Initialization service is not called until after OnWindowCreated which causes navigation to fail with dependencies loaded by a module.
- Removes public registration for IGlobalNavigationObserver in the Rx package. This will now automatically register the observer when provided a delegate.